### PR TITLE
[ADD] runbot_attach_vscode: data layer code-server (POC task #67684)

### DIFF
--- a/runbot_attach_vscode/README.rst
+++ b/runbot_attach_vscode/README.rst
@@ -1,0 +1,65 @@
+=====================
+Runbot Attach VS Code
+=====================
+
+Bakes `code-server <https://github.com/coder/code-server>`_ (VS Code in
+the browser) into runbot Dockerfiles via a reusable
+``runbot.docker_layer``. Each ``runbot.build`` exposes an *Open VS Code*
+button (internal users only) pointing at the wakeable URL.
+
+The module ships only the bake-in layer, the URL helper and the button.
+Proxy routing, port mapping and runtime ``code-server`` start are
+intentionally out of scope here and tracked as Phase 2.
+
+How to use
+==========
+
+#. Install the module on a runbot.
+#. In *Runbot → Configuration → Dockerfiles*, pick the target Dockerfile
+   (or a variant), and add a new layer with
+   ``layer_type = reference_layer`` pointing at
+   ``runbot_attach_vscode.docker_layer_code_server``. Sequence ``200``
+   works as a safe default (renders after the standard layers).
+#. Rebuild the image and wake a build. The *Open VS Code* button on
+   the build form points at ``<scheme>://<dest>-<suffix>.<host>``.
+
+Configuration
+=============
+
+Two system parameters drive the URL:
+
+``runbot_attach_vscode.url_suffix``
+    Suffix appended to ``build.dest``. Default: ``vscode``.
+
+``runbot_attach_vscode.scheme``
+    URL scheme. Default: ``https``.
+
+The pinned code-server version lives in the layer's ``values`` field
+(``CODE_SERVER_VERSION``, default ``4.96.4``). To override per
+Dockerfile, set the ``values`` JSON of the consuming
+``reference_layer`` — see ``runbot.docker_layer._render_template`` for
+the merge order (base + source + caller).
+
+Status
+======
+
+Phase 1 (this module):
+
+* Reusable ``runbot.docker_layer`` (template).
+* Computed ``vscode_url`` field on ``runbot.build``.
+* *Open VS Code* button restricted to ``base.group_user``.
+
+Phase 2 (pending, separate iteration):
+
+* Nginx routing for ``<dest>-vscode.<host>`` → container port 8080.
+* Port mapping in the ``runbot.build`` container spec.
+* Start ``code-server`` on wake-up via ``docker exec``.
+* Short-lived auth token instead of ``--auth none``.
+
+Credits
+=======
+
+Authors
+~~~~~~~
+
+* ADHOC SA

--- a/runbot_attach_vscode/README.rst
+++ b/runbot_attach_vscode/README.rst
@@ -4,12 +4,10 @@ Runbot Attach VS Code
 
 Bakes `code-server <https://github.com/coder/code-server>`_ (VS Code in
 the browser) into runbot Dockerfiles via a reusable
-``runbot.docker_layer``. Each ``runbot.build`` exposes an *Open VS Code*
-button (internal users only) pointing at the wakeable URL.
-
-The module ships only the bake-in layer, the URL helper and the button.
-Proxy routing, port mapping and runtime ``code-server`` start are
-intentionally out of scope here and tracked as Phase 2.
+``runbot.docker_layer``. Each wakeable ``runbot.build`` whose Dockerfile
+attaches that layer exposes an *Open VS Code* button that resolves to a
+live code-server session running alongside Odoo inside the build's
+container.
 
 How to use
 ==========
@@ -20,8 +18,46 @@ How to use
    ``layer_type = reference_layer`` pointing at
    ``runbot_attach_vscode.docker_layer_code_server``. Sequence ``200``
    works as a safe default (renders after the standard layers).
-#. Rebuild the image and wake a build. The *Open VS Code* button on
-   the build form points at ``<scheme>://<dest>-<suffix>.<host>``.
+#. Rebuild the image and wake a build. The *Open VS Code* entry in the
+   build's action menu opens
+   ``<scheme>://<dest>-vscode.<host>`` in a new tab, which nginx routes
+   to the code-server session listening on container port 8071.
+
+How it works at run time
+========================
+
+code-server is started **lazily**: a wakeable build does not start
+code-server on every wake-up, only when someone actually clicks the
+*Open VS Code* entry. That keeps memory usage off the wake-up budget
+(automatic ``run_odoo`` steps inside CI configs would otherwise pay
+~150 MB per build for code-server, even when nobody attaches).
+
+On wake-up, the inherited ``_run_run_odoo`` step still reserves the
+mapping ``container 8071 → host build.port + 2`` (appended to
+``exposed_ports``), because Docker does not let us add port mappings to
+a running container later. It does **not** start code-server.
+
+When the user clicks the button, ``action_open_vscode``:
+
+#. Checks that the build container is in the ``RUNNING`` state.
+#. Runs ``docker exec`` inside the container (detached) with a shell
+   guard ``pgrep -x code-server >/dev/null || exec code-server …`` —
+   idempotent, so a second click is a no-op if code-server is already
+   up.
+#. Briefly polls the host port (up to 5s) so the browser does not race
+   against the bind.
+#. Returns the ``ir.actions.act_url`` pointing at ``vscode_url``.
+
+A QWeb inherit of ``runbot.nginx_config`` adds a per-build server block
+matching ``<dest>-vscode.<host>`` regex that proxies to
+``127.0.0.1:<build.port + 2>``, with the WebSocket headers code-server
+needs. The standard runbot nginx reload (triggered by ``_run_run_odoo``)
+picks the new block up.
+
+Both the run-step extension and the URL helper are no-ops when the
+build's Dockerfile does not attach the code-server reference layer
+(see ``_has_vscode_layer``), so builds on unrelated Dockerfiles keep
+working unchanged.
 
 Configuration
 =============
@@ -43,18 +79,30 @@ the merge order (base + source + caller).
 Status
 ======
 
-Phase 1 (this module):
+Phase 1 (shipped):
 
-* Reusable ``runbot.docker_layer`` (template).
-* Computed ``vscode_url`` field on ``runbot.build``.
-* *Open VS Code* button restricted to ``base.group_user``.
+* Reusable ``runbot.docker_layer`` template that installs code-server.
+* Stored ``vscode_url`` field on ``runbot.build``.
+* *Open VS Code* entry in the frontend build action menu and a button
+  on the backend build form, both restricted to ``base.group_user`` and
+  hidden when the Dockerfile does not include the layer.
 
-Phase 2 (pending, separate iteration):
+Phase 2 (shipped):
 
-* Nginx routing for ``<dest>-vscode.<host>`` → container port 8080.
-* Port mapping in the ``runbot.build`` container spec.
-* Start ``code-server`` on wake-up via ``docker exec``.
-* Short-lived auth token instead of ``--auth none``.
+* ``_run_run_odoo`` extension that reserves the container port 8071 →
+  host ``build.port + 2`` mapping at wake-up time.
+* ``action_open_vscode`` starts code-server on demand via
+  ``docker exec`` (idempotent) and waits briefly for it to bind.
+* Nginx server block inserted per build via QWeb inherit so that
+  ``<dest>-vscode.<host>`` routes to that port.
+
+Phase 3 (pending):
+
+* Replace ``--auth none`` with a short-lived token issued by Odoo and
+  validated by code-server (today access is gated only by the runbot
+  nginx exposure being on the internal Adhoc network).
+* Writable scratch directory configured as the default code-server
+  workspace so devs can edit beyond the read-only source mounts.
 
 Credits
 =======

--- a/runbot_attach_vscode/__init__.py
+++ b/runbot_attach_vscode/__init__.py
@@ -1,1 +1,2 @@
+from . import controllers
 from . import models

--- a/runbot_attach_vscode/__init__.py
+++ b/runbot_attach_vscode/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/runbot_attach_vscode/__manifest__.py
+++ b/runbot_attach_vscode/__manifest__.py
@@ -10,6 +10,7 @@
         "data/ir_config_parameter.xml",
         "data/runbot_docker_layer.xml",
         "views/runbot_build_views.xml",
+        "views/runbot_frontend_templates.xml",
     ],
     "license": "AGPL-3",
     "installable": True,

--- a/runbot_attach_vscode/__manifest__.py
+++ b/runbot_attach_vscode/__manifest__.py
@@ -12,6 +12,9 @@
         "views/runbot_build_views.xml",
         "views/runbot_frontend_templates.xml",
     ],
+    "demo": [
+        "demo/runbot_attach_vscode_demo.xml",
+    ],
     "license": "AGPL-3",
     "installable": True,
 }

--- a/runbot_attach_vscode/__manifest__.py
+++ b/runbot_attach_vscode/__manifest__.py
@@ -11,6 +11,7 @@
         "data/runbot_docker_layer.xml",
         "views/runbot_build_views.xml",
         "views/runbot_frontend_templates.xml",
+        "views/runbot_nginx.xml",
     ],
     "demo": [
         "demo/runbot_attach_vscode_demo.xml",

--- a/runbot_attach_vscode/__manifest__.py
+++ b/runbot_attach_vscode/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "Runbot Attach VS Code",
+    "summary": "Attach a code-server VS Code session to a wakeable runbot build",
+    "author": "ADHOC SA",
+    "website": "https://www.adhoc.com.ar",
+    "category": "Website",
+    "version": "18.0.1.0.0",
+    "depends": ["runbot"],
+    "data": [
+        "data/runbot_docker_layer.xml",
+    ],
+    "license": "AGPL-3",
+    "installable": True,
+}

--- a/runbot_attach_vscode/__manifest__.py
+++ b/runbot_attach_vscode/__manifest__.py
@@ -4,10 +4,12 @@
     "author": "ADHOC SA",
     "website": "https://www.adhoc.com.ar",
     "category": "Website",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "depends": ["runbot"],
     "data": [
+        "data/ir_config_parameter.xml",
         "data/runbot_docker_layer.xml",
+        "views/runbot_build_views.xml",
     ],
     "license": "AGPL-3",
     "installable": True,

--- a/runbot_attach_vscode/controllers/__init__.py
+++ b/runbot_attach_vscode/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/runbot_attach_vscode/controllers/main.py
+++ b/runbot_attach_vscode/controllers/main.py
@@ -1,0 +1,49 @@
+import logging
+
+from odoo import _, http
+from odoo.addons.runbot.container import docker_state
+from odoo.exceptions import UserError
+from odoo.http import request
+
+_logger = logging.getLogger(__name__)
+
+
+class VsCodeController(http.Controller):
+    @http.route(
+        ["/runbot/vscode/<int:build_id>"],
+        type="http",
+        auth="user",
+        website=True,
+        sitemap=False,
+    )
+    def open_vscode(self, build_id):
+        """Lazy entry point for the frontend 'Open VS Code' dropdown.
+
+        Starts code-server inside the build container (idempotent) and
+        redirects the browser to the vscode_url. The frontend template
+        cannot call the action_open_vscode model method directly because
+        the dropdown is a plain <a> tag — it would navigate the browser
+        to vscode_url straight away, bypassing the docker exec.
+        """
+        if not request.env.user._is_internal():
+            return request.not_found()
+        build = request.env["runbot.build"].browse(build_id).sudo()
+        if not build.exists() or not build.vscode_url:
+            return request.not_found()
+        container_name = build._get_docker_name()
+        if docker_state(container_name, build._path()) != "RUNNING":
+            return request.render(
+                "http_routing.http_error",
+                {
+                    "status_code": _("Build not running"),
+                    "status_message": _("Wake the build up before opening VS Code."),
+                },
+            )
+        try:
+            build._ensure_code_server_running(container_name)
+        except UserError as exc:
+            return request.render(
+                "http_routing.http_error",
+                {"status_code": _("VS Code"), "status_message": exc.args[0]},
+            )
+        return request.redirect(build.vscode_url, code=302)

--- a/runbot_attach_vscode/controllers/main.py
+++ b/runbot_attach_vscode/controllers/main.py
@@ -46,4 +46,4 @@ class VsCodeController(http.Controller):
                 "http_routing.http_error",
                 {"status_code": _("VS Code"), "status_message": exc.args[0]},
             )
-        return request.redirect(build.vscode_url, code=302)
+        return request.redirect(build.vscode_url, code=302, local=False)

--- a/runbot_attach_vscode/controllers/main.py
+++ b/runbot_attach_vscode/controllers/main.py
@@ -1,14 +1,66 @@
+import base64
+import hashlib
+import hmac
 import logging
+import time
 
 from odoo import _, http
 from odoo.addons.runbot.container import docker_state
 from odoo.exceptions import UserError
-from odoo.http import request
+from odoo.http import Response, request
 
 _logger = logging.getLogger(__name__)
 
+TOKEN_COOKIE = "vscode_token"
+TOKEN_TTL_SECONDS = 4 * 3600
+
 
 class VsCodeController(http.Controller):
+    """code-server entry-point + auth_check used by the per-build nginx block.
+
+    The session model: when an internal user clicks "Open VS Code", the
+    `/runbot/vscode/<id>` route issues an HMAC-signed cookie scoped to
+    the parent domain (so the browser sends it on the <dest>-vscode.<host>
+    subdomain). The runbot internal nginx block runs `auth_request` on
+    every request to that subdomain — the sub-request hits
+    `/runbot/vscode/auth_check?build=<id>` and validates the cookie. No
+    valid cookie ⇒ 401 ⇒ nginx redirects back to /runbot/vscode/<id>,
+    which re-issues (or bounces to /web/login if no session).
+    """
+
+    @staticmethod
+    def _vscode_secret():
+        param = request.env["ir.config_parameter"].sudo().get_param("database.secret")
+        if not param:
+            # database.secret is initialized lazily; fall back to the cookie
+            # key so verify-after-restart still works deterministically.
+            param = request.env["ir.config_parameter"].sudo().get_param("database.uuid", "")
+        return (param or "").encode()
+
+    @classmethod
+    def _make_token(cls, build_id, user_id, exp):
+        payload = f"{int(build_id)}|{int(user_id)}|{int(exp)}".encode()
+        sig = hmac.new(cls._vscode_secret(), payload, hashlib.sha256).digest()
+        return base64.urlsafe_b64encode(payload + b"." + sig).decode().rstrip("=")
+
+    @classmethod
+    def _verify_token(cls, token, build_id):
+        try:
+            padded = token + "=" * (-len(token) % 4)
+            raw = base64.urlsafe_b64decode(padded.encode())
+            payload, sig = raw.rsplit(b".", 1)
+            expected = hmac.new(cls._vscode_secret(), payload, hashlib.sha256).digest()
+            if not hmac.compare_digest(sig, expected):
+                return False
+            tok_build, _tok_user, exp = payload.decode().split("|")
+            if int(tok_build) != int(build_id):
+                return False
+            if int(exp) < int(time.time()):
+                return False
+            return True
+        except Exception:
+            return False
+
     @http.route(
         ["/runbot/vscode/<int:build_id>"],
         type="http",
@@ -17,13 +69,11 @@ class VsCodeController(http.Controller):
         sitemap=False,
     )
     def open_vscode(self, build_id):
-        """Lazy entry point for the frontend 'Open VS Code' dropdown.
+        """Issue the auth cookie + start code-server lazily + redirect.
 
-        Starts code-server inside the build container (idempotent) and
-        redirects the browser to the vscode_url. The frontend template
-        cannot call the action_open_vscode model method directly because
-        the dropdown is a plain <a> tag — it would navigate the browser
-        to vscode_url straight away, bypassing the docker exec.
+        Both the backend "Open VS Code" button and the frontend dropdown
+        funnel through this route so the cookie can be set on the parent
+        domain (model methods can't attach cookies to act_url responses).
         """
         if not request.env.user._is_internal():
             return request.not_found()
@@ -46,4 +96,41 @@ class VsCodeController(http.Controller):
                 "http_routing.http_error",
                 {"status_code": _("VS Code"), "status_message": exc.args[0]},
             )
-        return request.redirect(build.vscode_url, code=302, local=False)
+        exp = int(time.time()) + TOKEN_TTL_SECONDS
+        token = self._make_token(build.id, request.env.user.id, exp)
+        response = request.redirect(build.vscode_url, code=302, local=False)
+        # Setting Domain= to the build's host scopes the cookie to that
+        # host *and* all subdomains under it (RFC 6265), which is exactly
+        # what we need: Odoo runs on <host>, code-server is reached on
+        # <dest>-vscode.<host>, and the browser sends the cookie to both.
+        response.set_cookie(
+            TOKEN_COOKIE,
+            token,
+            max_age=TOKEN_TTL_SECONDS,
+            domain=build.host,
+            secure=True,
+            httponly=True,
+            samesite="Lax",
+            path="/",
+        )
+        return response
+
+    @http.route(
+        ["/runbot/vscode/auth_check"],
+        type="http",
+        auth="public",
+        csrf=False,
+        sitemap=False,
+    )
+    def auth_check(self, build=None):
+        """Sub-request target for nginx `auth_request`. Returns 200 only when
+        the request carries a valid, non-expired token cookie for the given
+        build. nginx forwards the browser's Cookie header automatically."""
+        if not build:
+            return Response(status=401)
+        token = request.httprequest.cookies.get(TOKEN_COOKIE, "")
+        if not token:
+            return Response(status=401)
+        if self._verify_token(token, build):
+            return Response(status=200)
+        return Response(status=401)

--- a/runbot_attach_vscode/data/ir_config_parameter.xml
+++ b/runbot_attach_vscode/data/ir_config_parameter.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="ir_config_parameter_url_suffix" model="ir.config_parameter">
+        <field name="key">runbot_attach_vscode.url_suffix</field>
+        <field name="value">vscode</field>
+    </record>
+
+    <record id="ir_config_parameter_scheme" model="ir.config_parameter">
+        <field name="key">runbot_attach_vscode.scheme</field>
+        <field name="value">https</field>
+    </record>
+
+</odoo>

--- a/runbot_attach_vscode/data/runbot_docker_layer.xml
+++ b/runbot_attach_vscode/data/runbot_docker_layer.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo noupdate="1">
+<odoo>
 
     <record id="docker_layer_code_server" model="runbot.docker_layer">
         <field name="name">code_server</field>
         <field name="sequence">200</field>
-        <field name="layer_type">raw</field>
-        <field name="content"># Layer: code-server (runbot_attach_vscode)
+        <field name="layer_type">template</field>
+        <field name="content"># Layer: code-server v{CODE_SERVER_VERSION} (runbot_attach_vscode)
 USER root
-RUN curl -fsSL https://code-server.dev/install.sh | sh \
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version {CODE_SERVER_VERSION} \
     &amp;&amp; rm -rf /var/lib/apt/lists/*
 USER runbot</field>
+        <field name="values" eval="{'CODE_SERVER_VERSION': '4.96.4'}"/>
     </record>
 
 </odoo>

--- a/runbot_attach_vscode/data/runbot_docker_layer.xml
+++ b/runbot_attach_vscode/data/runbot_docker_layer.xml
@@ -1,14 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <!-- Bake-in: code-server (web editor) + AI CLIs (Claude Code, OpenCode,
+         OpenAI Codex, Google Gemini). Installed as a single RUN to keep
+         image-layer count down. Node 20 via NodeSource is required by the
+         three npm-distributed CLIs. -->
     <record id="docker_layer_code_server" model="runbot.docker_layer">
         <field name="name">code_server</field>
         <field name="sequence">200</field>
         <field name="layer_type">template</field>
-        <field name="content"># Layer: code-server v{CODE_SERVER_VERSION} (runbot_attach_vscode)
+        <field name="content"># Layer: code-server v{CODE_SERVER_VERSION} + AI CLIs (runbot_attach_vscode)
 USER root
 RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version {CODE_SERVER_VERSION} \
-    &amp;&amp; rm -rf /var/lib/apt/lists/*
+    &amp;&amp; curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    &amp;&amp; apt-get install -y --no-install-recommends nodejs \
+    &amp;&amp; npm install -g --silent \
+        @anthropic-ai/claude-code \
+        @openai/codex \
+        @google/gemini-cli \
+        opencode-ai \
+    &amp;&amp; rm -rf /var/lib/apt/lists/* /root/.npm /tmp/*
 USER runbot</field>
         <field name="values" eval="{'CODE_SERVER_VERSION': '4.96.4'}"/>
     </record>

--- a/runbot_attach_vscode/data/runbot_docker_layer.xml
+++ b/runbot_attach_vscode/data/runbot_docker_layer.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="docker_layer_code_server" model="runbot.docker_layer">
+        <field name="name">code_server</field>
+        <field name="sequence">200</field>
+        <field name="layer_type">raw</field>
+        <field name="content"># Layer: code-server (runbot_attach_vscode)
+USER root
+RUN curl -fsSL https://code-server.dev/install.sh | sh \
+    &amp;&amp; rm -rf /var/lib/apt/lists/*
+USER runbot</field>
+    </record>
+
+</odoo>

--- a/runbot_attach_vscode/demo/runbot_attach_vscode_demo.xml
+++ b/runbot_attach_vscode/demo/runbot_attach_vscode_demo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- Attaches code-server to the runbot default Dockerfile, so every demo
+         build that uses it is reachable via VS Code. Loaded with demo data
+         only; the admin can delete this record if they want demo builds
+         without code-server, without it being re-created on update. -->
+    <record id="docker_default_cs_ref" model="runbot.docker_layer">
+        <field name="name">cs_ref</field>
+        <field name="dockerfile_id" ref="runbot.docker_default"/>
+        <field name="layer_type">reference_layer</field>
+        <field name="reference_docker_layer_id" ref="docker_layer_code_server"/>
+        <field name="sequence">200</field>
+    </record>
+
+    <!-- Force vscode_url recompute on builds created before this file loaded
+         (vscode_url stores once and only depends on dest + host, so the new
+         reference layer above does not propagate on its own). -->
+    <function model="runbot.build" name="_compute_vscode_url">
+        <value model="runbot.build" eval="obj().search([]).ids"/>
+    </function>
+
+</odoo>

--- a/runbot_attach_vscode/models/__init__.py
+++ b/runbot_attach_vscode/models/__init__.py
@@ -1,0 +1,1 @@
+from . import runbot_build

--- a/runbot_attach_vscode/models/__init__.py
+++ b/runbot_attach_vscode/models/__init__.py
@@ -1,1 +1,2 @@
 from . import runbot_build
+from . import runbot_build_config

--- a/runbot_attach_vscode/models/runbot_build.py
+++ b/runbot_attach_vscode/models/runbot_build.py
@@ -1,0 +1,33 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class RunbotBuild(models.Model):
+    _inherit = "runbot.build"
+
+    vscode_url = fields.Char(compute="_compute_vscode_url")
+
+    @api.depends("dest", "host")
+    def _compute_vscode_url(self):
+        get_param = self.env["ir.config_parameter"].sudo().get_param
+        suffix = get_param("runbot_attach_vscode.url_suffix", default="vscode")
+        scheme = get_param("runbot_attach_vscode.scheme", default="https")
+        for build in self:
+            if build.dest and build.host:
+                build.vscode_url = f"{scheme}://{build.dest}-{suffix}.{build.host}"
+            else:
+                build.vscode_url = False
+
+    def action_open_vscode(self):
+        self.ensure_one()
+        if not self.env.user._is_internal():
+            raise UserError(_("Only internal users can open a VS Code session."))
+        if not self.vscode_url:
+            raise UserError(
+                _("Build has no destination/host yet — wake it first."),
+            )
+        return {
+            "type": "ir.actions.act_url",
+            "url": self.vscode_url,
+            "target": "new",
+        }

--- a/runbot_attach_vscode/models/runbot_build.py
+++ b/runbot_attach_vscode/models/runbot_build.py
@@ -29,13 +29,18 @@ class RunbotBuild(models.Model):
             for layer in self.params_id.dockerfile_id.layer_ids
         )
 
-    @api.depends("dest", "host", "params_id.dockerfile_id")
+    @api.depends("global_state", "params_id.dockerfile_id")
     def _compute_vscode_url(self):
         get_param = self.env["ir.config_parameter"].sudo().get_param
         suffix = get_param("runbot_attach_vscode.url_suffix", default="vscode")
         scheme = get_param("runbot_attach_vscode.scheme", default="https")
         for build in self:
-            if build.dest and build.host and build._has_vscode_layer():
+            if (
+                build.global_state in ("done", "running")
+                and build.dest
+                and build.host
+                and build._has_vscode_layer()
+            ):
                 build.vscode_url = f"{scheme}://{build.dest}-{suffix}.{build.host}"
             else:
                 build.vscode_url = False

--- a/runbot_attach_vscode/models/runbot_build.py
+++ b/runbot_attach_vscode/models/runbot_build.py
@@ -35,12 +35,7 @@ class RunbotBuild(models.Model):
         suffix = get_param("runbot_attach_vscode.url_suffix", default="vscode")
         scheme = get_param("runbot_attach_vscode.scheme", default="https")
         for build in self:
-            if (
-                build.global_state in ("done", "running")
-                and build.dest
-                and build.host
-                and build._has_vscode_layer()
-            ):
+            if build.global_state in ("done", "running") and build.dest and build.host and build._has_vscode_layer():
                 build.vscode_url = f"{scheme}://{build.dest}-{suffix}.{build.host}"
             else:
                 build.vscode_url = False

--- a/runbot_attach_vscode/models/runbot_build.py
+++ b/runbot_attach_vscode/models/runbot_build.py
@@ -61,22 +61,14 @@ class RunbotBuild(models.Model):
         }
 
     def _ensure_code_server_running(self, container_name):
-        """Idempotently start code-server inside the running build container.
+        """Start code-server inside the running build container.
 
-        Uses the docker CLI directly via subprocess. We previously used
-        docker-py's exec_run(detach=True), but with that combination the
-        container's process did not survive the SDK call (likely because
-        AttachStdout/Stderr stay true and conflict with Detach=true).
-        Calling `docker exec -d` straight is the path we verified works
-        manually.
-
-        The shell guard (`pgrep -f code-server >/dev/null || exec
-        code-server ...`) makes a second click a no-op if code-server is
-        already up.
+        Repeated calls are safe: if code-server is already up, a second
+        attempt fails with EADDRINUSE and exits without affecting the
+        running instance.
         """
         inner_cmd = (
-            "pgrep -f code-server >/dev/null || "
-            f"exec code-server --bind-addr 0.0.0.0:{VSCODE_CONTAINER_PORT} "
+            f"code-server --bind-addr 0.0.0.0:{VSCODE_CONTAINER_PORT} "
             "--auth none /data/build "
             ">/tmp/code-server.log 2>&1"
         )

--- a/runbot_attach_vscode/models/runbot_build.py
+++ b/runbot_attach_vscode/models/runbot_build.py
@@ -4,7 +4,6 @@ import subprocess
 import time
 
 from odoo import _, api, fields, models
-from odoo.addons.runbot.container import docker_state
 from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
@@ -41,6 +40,10 @@ class RunbotBuild(models.Model):
                 build.vscode_url = False
 
     def action_open_vscode(self):
+        """Backend button entry-point. We funnel through the HTTP controller
+        (rather than redirecting straight to vscode_url) because the
+        controller has to set the auth cookie on the parent domain — model
+        methods returning `ir.actions.act_url` can't attach cookies."""
         self.ensure_one()
         if not self.env.user._is_internal():
             raise UserError(_("Only internal users can open a VS Code session."))
@@ -48,15 +51,9 @@ class RunbotBuild(models.Model):
             raise UserError(
                 _("Build has no destination/host yet — wake it first."),
             )
-        container_name = self._get_docker_name()
-        if docker_state(container_name, self._path()) != "RUNNING":
-            raise UserError(
-                _("Build container is not running. Wake it up before opening VS Code."),
-            )
-        self._ensure_code_server_running(container_name)
         return {
             "type": "ir.actions.act_url",
-            "url": self.vscode_url,
+            "url": f"/runbot/vscode/{self.id}",
             "target": "new",
         }
 

--- a/runbot_attach_vscode/models/runbot_build.py
+++ b/runbot_attach_vscode/models/runbot_build.py
@@ -29,7 +29,7 @@ class RunbotBuild(models.Model):
             for layer in self.params_id.dockerfile_id.layer_ids
         )
 
-    @api.depends("dest", "host")
+    @api.depends("dest", "host", "params_id.dockerfile_id")
     def _compute_vscode_url(self):
         get_param = self.env["ir.config_parameter"].sudo().get_param
         suffix = get_param("runbot_attach_vscode.url_suffix", default="vscode")

--- a/runbot_attach_vscode/models/runbot_build.py
+++ b/runbot_attach_vscode/models/runbot_build.py
@@ -1,5 +1,16 @@
+import logging
+import socket
+import time
+
+import docker
 from odoo import _, api, fields, models
+from odoo.addons.runbot.container import docker_state
 from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+VSCODE_CONTAINER_PORT = 8071
+VSCODE_READY_TIMEOUT = 5.0
 
 
 class RunbotBuild(models.Model):
@@ -7,18 +18,24 @@ class RunbotBuild(models.Model):
 
     vscode_url = fields.Char(compute="_compute_vscode_url", store=True)
 
+    def _has_vscode_layer(self):
+        """True if the build's Dockerfile attaches our code-server reference layer."""
+        self.ensure_one()
+        source_layer = self.env.ref("runbot_attach_vscode.docker_layer_code_server", raise_if_not_found=False)
+        if not source_layer:
+            return False
+        return any(
+            layer.layer_type == "reference_layer" and layer.reference_docker_layer_id == source_layer
+            for layer in self.params_id.dockerfile_id.layer_ids
+        )
+
     @api.depends("dest", "host")
     def _compute_vscode_url(self):
         get_param = self.env["ir.config_parameter"].sudo().get_param
         suffix = get_param("runbot_attach_vscode.url_suffix", default="vscode")
         scheme = get_param("runbot_attach_vscode.scheme", default="https")
-        source_layer = self.env.ref("runbot_attach_vscode.docker_layer_code_server", raise_if_not_found=False)
         for build in self:
-            has_layer = bool(source_layer) and any(
-                layer.layer_type == "reference_layer" and layer.reference_docker_layer_id == source_layer
-                for layer in build.params_id.dockerfile_id.layer_ids
-            )
-            if build.dest and build.host and has_layer:
+            if build.dest and build.host and build._has_vscode_layer():
                 build.vscode_url = f"{scheme}://{build.dest}-{suffix}.{build.host}"
             else:
                 build.vscode_url = False
@@ -31,8 +48,59 @@ class RunbotBuild(models.Model):
             raise UserError(
                 _("Build has no destination/host yet — wake it first."),
             )
+        container_name = self._get_docker_name()
+        if docker_state(container_name, self._path()) != "RUNNING":
+            raise UserError(
+                _("Build container is not running. Wake it up before opening VS Code."),
+            )
+        self._ensure_code_server_running(container_name)
         return {
             "type": "ir.actions.act_url",
             "url": self.vscode_url,
             "target": "new",
         }
+
+    def _ensure_code_server_running(self, container_name):
+        """Idempotently start code-server inside the running build container.
+
+        Uses `docker exec` with detach so the call returns immediately. The
+        shell guard (`pgrep ... || exec code-server ...`) makes a second
+        click a no-op if code-server is already up. After kicking off the
+        exec, we briefly poll the host port until code-server starts
+        accepting connections so the user's browser does not race against
+        the bind.
+        """
+        try:
+            container = docker.from_env().containers.get(container_name)
+            container.exec_run(
+                [
+                    "sh",
+                    "-c",
+                    "pgrep -x code-server >/dev/null || "
+                    f"exec code-server --bind-addr 0.0.0.0:{VSCODE_CONTAINER_PORT} "
+                    "--auth none /data/build",
+                ],
+                detach=True,
+            )
+        except docker.errors.NotFound:
+            raise UserError(
+                _("Build container '%s' not found.", container_name),
+            )
+        except Exception:
+            _logger.exception("Failed to start code-server in %s", container_name)
+            raise UserError(
+                _("Could not start code-server in the build container. Check the runbot logs."),
+            )
+        deadline = time.monotonic() + VSCODE_READY_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", self.port + 2), timeout=0.3):
+                    return
+            except OSError:
+                time.sleep(0.3)
+        _logger.warning(
+            "code-server did not start listening on port %s within %ss for build %s",
+            self.port + 2,
+            VSCODE_READY_TIMEOUT,
+            self.id,
+        )

--- a/runbot_attach_vscode/models/runbot_build.py
+++ b/runbot_attach_vscode/models/runbot_build.py
@@ -1,8 +1,8 @@
 import logging
 import socket
+import subprocess
 import time
 
-import docker
 from odoo import _, api, fields, models
 from odoo.addons.runbot.container import docker_state
 from odoo.exceptions import UserError
@@ -63,35 +63,40 @@ class RunbotBuild(models.Model):
     def _ensure_code_server_running(self, container_name):
         """Idempotently start code-server inside the running build container.
 
-        Uses `docker exec` with detach so the call returns immediately. The
-        shell guard (`pgrep ... || exec code-server ...`) makes a second
-        click a no-op if code-server is already up. After kicking off the
-        exec, we briefly poll the host port until code-server starts
-        accepting connections so the user's browser does not race against
-        the bind.
+        Uses the docker CLI directly via subprocess. We previously used
+        docker-py's exec_run(detach=True), but with that combination the
+        container's process did not survive the SDK call (likely because
+        AttachStdout/Stderr stay true and conflict with Detach=true).
+        Calling `docker exec -d` straight is the path we verified works
+        manually.
+
+        The shell guard (`pgrep -f code-server >/dev/null || exec
+        code-server ...`) makes a second click a no-op if code-server is
+        already up.
         """
+        inner_cmd = (
+            "pgrep -f code-server >/dev/null || "
+            f"exec code-server --bind-addr 0.0.0.0:{VSCODE_CONTAINER_PORT} "
+            "--auth none /data/build "
+            ">/tmp/code-server.log 2>&1"
+        )
         try:
-            container = docker.from_env().containers.get(container_name)
-            container.exec_run(
-                [
-                    "sh",
-                    "-c",
-                    "pgrep -f code-server >/dev/null || "
-                    f"exec code-server --bind-addr 0.0.0.0:{VSCODE_CONTAINER_PORT} "
-                    "--auth none /data/build "
-                    ">/tmp/code-server.log 2>&1",
-                ],
-                detach=True,
+            result = subprocess.run(
+                ["docker", "exec", "-d", container_name, "sh", "-c", inner_cmd],
+                capture_output=True,
+                timeout=10,
+                check=False,
             )
-        except docker.errors.NotFound:
-            raise UserError(
-                _("Build container '%s' not found.", container_name),
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            _logger.exception("docker exec failed for %s", container_name)
+            raise UserError(_("Could not start code-server in the build container."))
+        if result.returncode != 0:
+            _logger.error(
+                "docker exec to start code-server failed (rc=%s): %s",
+                result.returncode,
+                result.stderr.decode("utf-8", errors="replace"),
             )
-        except Exception:
-            _logger.exception("Failed to start code-server in %s", container_name)
-            raise UserError(
-                _("Could not start code-server in the build container. Check the runbot logs."),
-            )
+            raise UserError(_("Could not start code-server in the build container."))
         deadline = time.monotonic() + VSCODE_READY_TIMEOUT
         while time.monotonic() < deadline:
             try:

--- a/runbot_attach_vscode/models/runbot_build.py
+++ b/runbot_attach_vscode/models/runbot_build.py
@@ -76,9 +76,10 @@ class RunbotBuild(models.Model):
                 [
                     "sh",
                     "-c",
-                    "pgrep -x code-server >/dev/null || "
+                    "pgrep -f code-server >/dev/null || "
                     f"exec code-server --bind-addr 0.0.0.0:{VSCODE_CONTAINER_PORT} "
-                    "--auth none /data/build",
+                    "--auth none /data/build "
+                    ">/tmp/code-server.log 2>&1",
                 ],
                 detach=True,
             )

--- a/runbot_attach_vscode/models/runbot_build.py
+++ b/runbot_attach_vscode/models/runbot_build.py
@@ -5,15 +5,20 @@ from odoo.exceptions import UserError
 class RunbotBuild(models.Model):
     _inherit = "runbot.build"
 
-    vscode_url = fields.Char(compute="_compute_vscode_url")
+    vscode_url = fields.Char(compute="_compute_vscode_url", store=True)
 
     @api.depends("dest", "host")
     def _compute_vscode_url(self):
         get_param = self.env["ir.config_parameter"].sudo().get_param
         suffix = get_param("runbot_attach_vscode.url_suffix", default="vscode")
         scheme = get_param("runbot_attach_vscode.scheme", default="https")
+        source_layer = self.env.ref("runbot_attach_vscode.docker_layer_code_server", raise_if_not_found=False)
         for build in self:
-            if build.dest and build.host:
+            has_layer = bool(source_layer) and any(
+                layer.layer_type == "reference_layer" and layer.reference_docker_layer_id == source_layer
+                for layer in build.params_id.dockerfile_id.layer_ids
+            )
+            if build.dest and build.host and has_layer:
                 build.vscode_url = f"{scheme}://{build.dest}-{suffix}.{build.host}"
             else:
                 build.vscode_url = False

--- a/runbot_attach_vscode/models/runbot_build_config.py
+++ b/runbot_attach_vscode/models/runbot_build_config.py
@@ -1,0 +1,23 @@
+from odoo import models
+
+
+class BuildConfigStep(models.Model):
+    _inherit = "runbot.build.config.step"
+
+    def _run_run_odoo(self, build, force=False):
+        """Reserve container port 8071 → host port `build.port + 2` at
+        wake-up time when the build's Dockerfile carries the code-server
+        reference layer. The port mapping has to be declared at
+        `docker run` time (Docker does not let us add port mappings to a
+        running container later), but we do not start code-server here —
+        it is started lazily by `action_open_vscode` via `docker exec`
+        only when the user actually clicks the button.
+        """
+        run_step_data = super()._run_run_odoo(build, force=force)
+        if not run_step_data:
+            return run_step_data
+        if not build._has_vscode_layer():
+            return run_step_data
+
+        run_step_data["exposed_ports"] = list(run_step_data["exposed_ports"]) + [build.port + 2]
+        return run_step_data

--- a/runbot_attach_vscode/tests/__init__.py
+++ b/runbot_attach_vscode/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_runbot_attach_vscode

--- a/runbot_attach_vscode/tests/test_runbot_attach_vscode.py
+++ b/runbot_attach_vscode/tests/test_runbot_attach_vscode.py
@@ -1,0 +1,101 @@
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestRunbotAttachVscode(TransactionCase):
+    """Cubre layer template, reference_layer composition y action_open_vscode."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.source_layer = cls.env.ref("runbot_attach_vscode.docker_layer_code_server")
+
+    def test_source_layer_metadata(self):
+        self.assertEqual(self.source_layer.layer_type, "template")
+        self.assertEqual(dict(self.source_layer.values), {"CODE_SERVER_VERSION": "4.96.4"})
+
+    def test_source_layer_renders_default_version(self):
+        rendered = self.source_layer.rendered
+        self.assertIn("--version 4.96.4", rendered)
+        self.assertNotIn("{CODE_SERVER_VERSION}", rendered)
+
+    def test_reference_layer_inherits_default_version(self):
+        dockerfile = self.env["runbot.dockerfile"].create({"name": "test_attach_vscode"})
+        self.env["runbot.docker_layer"].create(
+            {
+                "name": "cs_ref",
+                "dockerfile_id": dockerfile.id,
+                "layer_type": "reference_layer",
+                "reference_docker_layer_id": self.source_layer.id,
+            }
+        )
+        self.assertIn("--version 4.96.4", dockerfile.dockerfile)
+
+    def test_reference_layer_overrides_version(self):
+        dockerfile = self.env["runbot.dockerfile"].create({"name": "test_attach_vscode_override"})
+        self.env["runbot.docker_layer"].create(
+            {
+                "name": "cs_ref_override",
+                "dockerfile_id": dockerfile.id,
+                "layer_type": "reference_layer",
+                "reference_docker_layer_id": self.source_layer.id,
+                "values": {"CODE_SERVER_VERSION": "4.97.0"},
+            }
+        )
+        self.assertIn("--version 4.97.0", dockerfile.dockerfile)
+        self.assertNotIn("--version 4.96.4", dockerfile.dockerfile)
+
+    def _new_build(self, dest=None, host=None):
+        build = self.env["runbot.build"].new({})
+        if dest is not None:
+            build.dest = dest
+        if host is not None:
+            build.host = host
+        build._compute_vscode_url()
+        return build
+
+    def test_vscode_url_built_from_dest_and_host(self):
+        build = self._new_build(dest="12345-19-0-x", host="runbot.example.com")
+        self.assertEqual(
+            build.vscode_url,
+            "https://12345-19-0-x-vscode.runbot.example.com",
+        )
+
+    def test_vscode_url_honours_config_parameters(self):
+        icp = self.env["ir.config_parameter"].sudo()
+        icp.set_param("runbot_attach_vscode.scheme", "http")
+        icp.set_param("runbot_attach_vscode.url_suffix", "ide")
+        build = self._new_build(dest="42-x", host="ci.adhoc.local")
+        self.assertEqual(build.vscode_url, "http://42-x-ide.ci.adhoc.local")
+
+    def test_vscode_url_empty_when_dest_missing(self):
+        build = self._new_build(host="runbot.example.com")
+        self.assertFalse(build.vscode_url)
+
+    def test_action_open_vscode_returns_act_url(self):
+        build = self._new_build(dest="12345-19-0-x", host="runbot.example.com")
+        result = build.action_open_vscode()
+        self.assertEqual(result["type"], "ir.actions.act_url")
+        self.assertEqual(result["target"], "new")
+        self.assertEqual(result["url"], "https://12345-19-0-x-vscode.runbot.example.com")
+
+    def test_action_open_vscode_blocks_when_url_missing(self):
+        build = self._new_build()
+        with self.assertRaises(UserError):
+            build.action_open_vscode()
+
+    def test_action_open_vscode_blocks_portal_user(self):
+        portal_user = self.env["res.users"].create(
+            {
+                "name": "Portal user",
+                "login": "portal_attach_vscode",
+                "groups_id": [(6, 0, [self.env.ref("base.group_portal").id])],
+            }
+        )
+        build = self.env["runbot.build"].with_user(portal_user).new({})
+        build.dest = "12345-19-0-x"
+        build.host = "runbot.example.com"
+        build._compute_vscode_url()
+        with self.assertRaises(UserError):
+            build.action_open_vscode()

--- a/runbot_attach_vscode/tests/test_runbot_attach_vscode.py
+++ b/runbot_attach_vscode/tests/test_runbot_attach_vscode.py
@@ -10,6 +10,27 @@ class TestRunbotAttachVscode(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.source_layer = cls.env.ref("runbot_attach_vscode.docker_layer_code_server")
+        # Dockerfile + reference layer that the vscode_url compute requires.
+        cls.dockerfile_with_layer = cls.env["runbot.dockerfile"].create(
+            {"name": "test_attach_vscode_dockerfile"},
+        )
+        cls.env["runbot.docker_layer"].create(
+            {
+                "name": "test_cs_ref",
+                "dockerfile_id": cls.dockerfile_with_layer.id,
+                "layer_type": "reference_layer",
+                "reference_docker_layer_id": cls.source_layer.id,
+            },
+        )
+        cls.version = cls.env["runbot.version"].create({"name": "test-vscode-version"})
+        cls.project = cls.env.ref("runbot.main_project")
+        cls.params = cls.env["runbot.build.params"].create(
+            {
+                "version_id": cls.version.id,
+                "project_id": cls.project.id,
+                "dockerfile_id": cls.dockerfile_with_layer.id,
+            },
+        )
 
     def test_reference_layer_overrides_version(self):
         dockerfile = self.env["runbot.dockerfile"].create({"name": "test_attach_vscode_override"})
@@ -25,8 +46,9 @@ class TestRunbotAttachVscode(TransactionCase):
         self.assertIn("--version 4.97.0", dockerfile.dockerfile)
         self.assertNotIn("--version 4.96.4", dockerfile.dockerfile)
 
-    def _new_build(self, dest=None, host=None):
+    def _new_build(self, dest=None, host=None, params=None):
         build = self.env["runbot.build"].new({})
+        build.params_id = params if params is not None else self.params
         if dest is not None:
             build.dest = dest
         if host is not None:
@@ -49,6 +71,19 @@ class TestRunbotAttachVscode(TransactionCase):
 
         # missing dest → short-circuit
         build = self._new_build(host="ci.example.com")
+        self.assertFalse(build.vscode_url)
+
+    def test_vscode_url_hidden_without_layer(self):
+        """Build with dest+host but the Dockerfile lacks our code-server reference."""
+        dockerfile_no_layer = self.env["runbot.dockerfile"].create({"name": "test_no_layer"})
+        params_no_layer = self.env["runbot.build.params"].create(
+            {
+                "version_id": self.version.id,
+                "project_id": self.project.id,
+                "dockerfile_id": dockerfile_no_layer.id,
+            },
+        )
+        build = self._new_build(dest="42-x", host="ci.example.com", params=params_no_layer)
         self.assertFalse(build.vscode_url)
 
     def test_action_open_vscode_blocks_when_url_missing(self):

--- a/runbot_attach_vscode/tests/test_runbot_attach_vscode.py
+++ b/runbot_attach_vscode/tests/test_runbot_attach_vscode.py
@@ -4,33 +4,12 @@ from odoo.tests import TransactionCase, tagged
 
 @tagged("-at_install", "post_install")
 class TestRunbotAttachVscode(TransactionCase):
-    """Cubre layer template, reference_layer composition y action_open_vscode."""
+    """Covers reference_layer override, vscode_url compute and action_open_vscode."""
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.source_layer = cls.env.ref("runbot_attach_vscode.docker_layer_code_server")
-
-    def test_source_layer_metadata(self):
-        self.assertEqual(self.source_layer.layer_type, "template")
-        self.assertEqual(dict(self.source_layer.values), {"CODE_SERVER_VERSION": "4.96.4"})
-
-    def test_source_layer_renders_default_version(self):
-        rendered = self.source_layer.rendered
-        self.assertIn("--version 4.96.4", rendered)
-        self.assertNotIn("{CODE_SERVER_VERSION}", rendered)
-
-    def test_reference_layer_inherits_default_version(self):
-        dockerfile = self.env["runbot.dockerfile"].create({"name": "test_attach_vscode"})
-        self.env["runbot.docker_layer"].create(
-            {
-                "name": "cs_ref",
-                "dockerfile_id": dockerfile.id,
-                "layer_type": "reference_layer",
-                "reference_docker_layer_id": self.source_layer.id,
-            }
-        )
-        self.assertIn("--version 4.96.4", dockerfile.dockerfile)
 
     def test_reference_layer_overrides_version(self):
         dockerfile = self.env["runbot.dockerfile"].create({"name": "test_attach_vscode_override"})
@@ -55,30 +34,22 @@ class TestRunbotAttachVscode(TransactionCase):
         build._compute_vscode_url()
         return build
 
-    def test_vscode_url_built_from_dest_and_host(self):
-        build = self._new_build(dest="12345-19-0-x", host="runbot.example.com")
-        self.assertEqual(
-            build.vscode_url,
-            "https://12345-19-0-x-vscode.runbot.example.com",
-        )
+    def test_vscode_url(self):
+        """Compute: default ICP, override, and short-circuit when dest is missing."""
+        # defaults (https / vscode)
+        build = self._new_build(dest="12345-19-0-x", host="ci.example.com")
+        self.assertEqual(build.vscode_url, "https://12345-19-0-x-vscode.ci.example.com")
 
-    def test_vscode_url_honours_config_parameters(self):
+        # ICP override
         icp = self.env["ir.config_parameter"].sudo()
         icp.set_param("runbot_attach_vscode.scheme", "http")
         icp.set_param("runbot_attach_vscode.url_suffix", "ide")
         build = self._new_build(dest="42-x", host="ci.adhoc.local")
         self.assertEqual(build.vscode_url, "http://42-x-ide.ci.adhoc.local")
 
-    def test_vscode_url_empty_when_dest_missing(self):
-        build = self._new_build(host="runbot.example.com")
+        # missing dest → short-circuit
+        build = self._new_build(host="ci.example.com")
         self.assertFalse(build.vscode_url)
-
-    def test_action_open_vscode_returns_act_url(self):
-        build = self._new_build(dest="12345-19-0-x", host="runbot.example.com")
-        result = build.action_open_vscode()
-        self.assertEqual(result["type"], "ir.actions.act_url")
-        self.assertEqual(result["target"], "new")
-        self.assertEqual(result["url"], "https://12345-19-0-x-vscode.runbot.example.com")
 
     def test_action_open_vscode_blocks_when_url_missing(self):
         build = self._new_build()
@@ -95,7 +66,7 @@ class TestRunbotAttachVscode(TransactionCase):
         )
         build = self.env["runbot.build"].with_user(portal_user).new({})
         build.dest = "12345-19-0-x"
-        build.host = "runbot.example.com"
+        build.host = "ci.example.com"
         build._compute_vscode_url()
         with self.assertRaises(UserError):
             build.action_open_vscode()

--- a/runbot_attach_vscode/views/runbot_build_views.xml
+++ b/runbot_attach_vscode/views/runbot_build_views.xml
@@ -16,9 +16,6 @@
                             class="oe_highlight"/>
                 </header>
             </xpath>
-            <xpath expr="//field[@name='build_url']" position="after">
-                <field name="vscode_url" widget="url" readonly="1"/>
-            </xpath>
         </field>
     </record>
 

--- a/runbot_attach_vscode/views/runbot_build_views.xml
+++ b/runbot_attach_vscode/views/runbot_build_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="runbot_build_form_vscode" model="ir.ui.view">
+        <field name="name">runbot.build.form.vscode</field>
+        <field name="model">runbot.build</field>
+        <field name="inherit_id" ref="runbot.build_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <header>
+                    <button name="action_open_vscode"
+                            type="object"
+                            string="Open VS Code"
+                            groups="base.group_user"
+                            invisible="not vscode_url"
+                            class="oe_highlight"/>
+                </header>
+            </xpath>
+            <xpath expr="//field[@name='build_url']" position="after">
+                <field name="vscode_url" widget="url" readonly="1"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/runbot_attach_vscode/views/runbot_frontend_templates.xml
+++ b/runbot_attach_vscode/views/runbot_frontend_templates.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="runbot_build_button_vscode" inherit_id="runbot.build_button">
+        <xpath expr="//a[@data-runbot='wakeup']" position="after">
+            <a groups="base.group_user"
+               t-if="bu.local_state == 'running' and bu.vscode_url"
+               t-att-href="bu.vscode_url"
+               target="_blank"
+               class="btn btn-default"
+               title="Open VS Code session"
+               aria-label="Open VS Code session">
+                <i class="fa fa-code"/>
+            </a>
+        </xpath>
+    </template>
+
+</odoo>

--- a/runbot_attach_vscode/views/runbot_frontend_templates.xml
+++ b/runbot_attach_vscode/views/runbot_frontend_templates.xml
@@ -10,7 +10,7 @@
                 <a class="dropdown-item"
                    groups="base.group_user"
                    t-if="bu.vscode_url"
-                   t-att-href="bu.vscode_url"
+                   t-attf-href="/runbot/vscode/{{bu.id}}"
                    target="_blank">
                     <i class="fa fa-code"/>
                     Open VS Code

--- a/runbot_attach_vscode/views/runbot_frontend_templates.xml
+++ b/runbot_attach_vscode/views/runbot_frontend_templates.xml
@@ -9,7 +9,7 @@
             <xpath expr="//a[i[hasclass('fa-refresh')]]" position="after">
                 <a class="dropdown-item"
                    groups="base.group_user"
-                   t-if="bu.global_state in ['done', 'running'] and bu.vscode_url"
+                   t-if="bu.vscode_url"
                    t-att-href="bu.vscode_url"
                    target="_blank">
                     <i class="fa fa-code"/>

--- a/runbot_attach_vscode/views/runbot_frontend_templates.xml
+++ b/runbot_attach_vscode/views/runbot_frontend_templates.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <template id="runbot_build_button_vscode" inherit_id="runbot.build_button">
-        <xpath expr="//a[@data-runbot='wakeup']" position="after">
-            <a groups="base.group_user"
-               t-if="bu.local_state == 'running' and bu.vscode_url"
-               t-att-href="bu.vscode_url"
-               target="_blank"
-               class="btn btn-default"
-               title="Open VS Code session"
-               aria-label="Open VS Code session">
-                <i class="fa fa-code"/>
-            </a>
-        </xpath>
-    </template>
+    <record id="runbot_build_menu_vscode" model="ir.ui.view">
+        <field name="name">runbot.build_menu.vscode</field>
+        <field name="type">qweb</field>
+        <field name="inherit_id" ref="runbot.build_menu"/>
+        <field name="arch" type="xml">
+            <xpath expr="//a[i[hasclass('fa-refresh')]]" position="after">
+                <a class="dropdown-item"
+                   groups="base.group_user"
+                   t-if="bu.global_state in ['done', 'running'] and bu.vscode_url"
+                   t-att-href="bu.vscode_url"
+                   target="_blank">
+                    <i class="fa fa-code"/>
+                    Open VS Code
+                </a>
+            </xpath>
+        </field>
+    </record>
 
 </odoo>

--- a/runbot_attach_vscode/views/runbot_nginx.xml
+++ b/runbot_attach_vscode/views/runbot_nginx.xml
@@ -10,8 +10,18 @@
          placed BEFORE the generic <dest>(-suffix)?.<host> block so its
          more specific regex matches the vscode subdomain first.
 
-         WebSocket headers (Upgrade/Connection) are required by
-         code-server for the editor RPC. -->
+         AUTH: every request runs `auth_request /__vscode_auth_check`, a
+         sub-request to the Odoo controller `/runbot/vscode/auth_check`
+         that validates an HMAC cookie (issued by /runbot/vscode/<id>).
+         No valid cookie ⇒ 401 ⇒ we redirect back to /runbot/vscode/<id>
+         on the parent host, which re-issues (or bounces to /web/login
+         when there is no Odoo session). The browser sends the cookie to
+         this subdomain because we set Domain=.<parent>.
+
+         The Connection header is upgrade-or-close depending on whether
+         the request carried an Upgrade header — this lets the same block
+         proxy both code-server's plain HTTP assets and its WebSocket RPC.
+         Read/send timeouts at 7d cover long-lived editor sessions. -->
     <record id="runbot_nginx_config_vscode" model="ir.ui.view">
         <field name="name">runbot.nginx_config.vscode</field>
         <field name="type">qweb</field>
@@ -21,16 +31,35 @@
 server {
     listen 8080;
     server_name ~^<t t-out="re_escape(build.dest)"/>-vscode\.<t t-out="re_escape(build.host)"/>$;
+
+    location = /__vscode_auth_check {
+        internal;
+        proxy_pass http://127.0.0.1:8069/runbot/vscode/auth_check?build=<t t-out="build.id"/>;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header Host <t t-out="build.host"/>;
+        proxy_set_header X-Forwarded-Proto $real_scheme;
+    }
+
+    location @vscode_login_redirect {
+        return 302 $real_scheme://<t t-out="build.host"/>/runbot/vscode/<t t-out="build.id"/>;
+    }
+
     location / {
+        auth_request /__vscode_auth_check;
+        error_page 401 403 = @vscode_login_redirect;
+
         proxy_pass http://127.0.0.1:<t t-out="build.port + 2"/>;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $real_scheme;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header X-Forwarded-For 127.0.0.42;
-        proxy_set_header X-Real-IP 127.0.0.42;
+        set $vscode_conn_upgrade upgrade;
+        if ($http_upgrade = "") { set $vscode_conn_upgrade close; }
+        proxy_set_header Connection $vscode_conn_upgrade;
+        proxy_read_timeout 7d;
+        proxy_send_timeout 7d;
     }
 }
             </xpath>

--- a/runbot_attach_vscode/views/runbot_nginx.xml
+++ b/runbot_attach_vscode/views/runbot_nginx.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Per-build server block that routes <dest>-vscode.<host> to the
+         code-server we start alongside Odoo on container port 8071, mapped
+         to host port build.port + 2 (see runbot_build_config.py).
+
+         Injected at the server_build_anchor inside the t-foreach over
+         builds, so each build gets its own block. Order matters: this is
+         placed BEFORE the generic <dest>(-suffix)?.<host> block so its
+         more specific regex matches the vscode subdomain first.
+
+         WebSocket headers (Upgrade/Connection) are required by
+         code-server for the editor RPC. -->
+    <record id="runbot_nginx_config_vscode" model="ir.ui.view">
+        <field name="name">runbot.nginx_config.vscode</field>
+        <field name="type">qweb</field>
+        <field name="inherit_id" ref="runbot.nginx_config"/>
+        <field name="arch" type="xml">
+            <xpath expr="//t[@id='server_build_anchor']" position="inside">
+server {
+    listen 8080;
+    server_name ~^<t t-out="re_escape(build.dest)"/>-vscode\.<t t-out="re_escape(build.host)"/>$;
+    location / {
+        proxy_pass http://127.0.0.1:<t t-out="build.port + 2"/>;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $real_scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_set_header X-Forwarded-For 127.0.0.42;
+        proxy_set_header X-Real-IP 127.0.0.42;
+    }
+}
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/runbot_ux/__manifest__.py
+++ b/runbot_ux/__manifest__.py
@@ -10,6 +10,9 @@
         "views/config_step_views.xml",
         "views/repo_views.xml",
     ],
+    "demo": [
+        "demo/runbot_ux_demo.xml",
+    ],
     "license": "AGPL-3",
     "installable": True,
 }

--- a/runbot_ux/demo/runbot_ux_demo.xml
+++ b/runbot_ux/demo/runbot_ux_demo.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- Version -->
+    <record id="version_18_0" model="runbot.version">
+        <field name="name">18.0</field>
+        <field name="sequence">180</field>
+    </record>
+
+    <!-- Repo + remote (mode=disabled to keep the demo inert) -->
+    <record id="repo_acme" model="runbot.repo">
+        <field name="name">acme-addons</field>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="mode">disabled</field>
+    </record>
+
+    <record id="remote_acme" model="runbot.remote">
+        <field name="name">git@example.local:acme/acme-addons.git</field>
+        <field name="repo_id" ref="repo_acme"/>
+    </record>
+
+    <!-- Trigger (drives the "[version] All" label on builds in the frontend) -->
+    <record id="trigger_all" model="runbot.trigger">
+        <field name="name">All</field>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="repo_ids" eval="[(6, 0, [ref('repo_acme')])]"/>
+        <field name="config_id" ref="runbot.runbot_build_config_default"/>
+    </record>
+
+    <!-- Bundles: base 18.0 + a feature branch -->
+    <record id="bundle_18_0" model="runbot.bundle">
+        <field name="name">18.0</field>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="is_base" eval="True"/>
+    </record>
+
+    <record id="bundle_feature" model="runbot.bundle">
+        <field name="name">18.0-t-99999-demo</field>
+        <field name="project_id" ref="runbot.main_project"/>
+    </record>
+
+    <!-- Commits -->
+    <record id="commit_main_a" model="runbot.commit">
+        <field name="name">9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b</field>
+        <field name="repo_id" ref="repo_acme"/>
+        <field name="author">Alice Demo</field>
+        <field name="author_email">alice@example.local</field>
+        <field name="subject">[ADD] demo_feature: initial scaffold</field>
+        <field name="tree_hash">aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111</field>
+    </record>
+
+    <record id="commit_main_b" model="runbot.commit">
+        <field name="name">1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c</field>
+        <field name="repo_id" ref="repo_acme"/>
+        <field name="author">Bob Demo</field>
+        <field name="author_email">bob@example.local</field>
+        <field name="subject">[REF] demo_feature: prune low-value tests</field>
+        <field name="tree_hash">bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222</field>
+    </record>
+
+    <record id="commit_feature_a" model="runbot.commit">
+        <field name="name">c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0</field>
+        <field name="repo_id" ref="repo_acme"/>
+        <field name="author">Alice Demo</field>
+        <field name="author_email">alice@example.local</field>
+        <field name="subject">[IMP] demo_feature: template layer + button</field>
+        <field name="tree_hash">cccc3333cccc3333cccc3333cccc3333cccc3333</field>
+    </record>
+
+    <record id="commit_feature_b" model="runbot.commit">
+        <field name="name">d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3</field>
+        <field name="repo_id" ref="repo_acme"/>
+        <field name="author">Alice Demo</field>
+        <field name="author_email">alice@example.local</field>
+        <field name="subject">[FIX] demo_feature: handle missing host gracefully</field>
+        <field name="tree_hash">dddd4444dddd4444dddd4444dddd4444dddd4444</field>
+    </record>
+
+    <!-- Commit links -->
+    <record id="commit_link_main_a" model="runbot.commit.link">
+        <field name="commit_id" ref="commit_main_a"/>
+    </record>
+
+    <record id="commit_link_main_b" model="runbot.commit.link">
+        <field name="commit_id" ref="commit_main_b"/>
+    </record>
+
+    <record id="commit_link_feature_a" model="runbot.commit.link">
+        <field name="commit_id" ref="commit_feature_a"/>
+    </record>
+
+    <record id="commit_link_feature_b" model="runbot.commit.link">
+        <field name="commit_id" ref="commit_feature_b"/>
+    </record>
+
+    <!-- Batches (mix of states) -->
+    <record id="batch_main_1" model="runbot.batch">
+        <field name="bundle_id" ref="bundle_18_0"/>
+        <field name="state">done</field>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_main_a')])]"/>
+    </record>
+
+    <record id="batch_main_2" model="runbot.batch">
+        <field name="bundle_id" ref="bundle_18_0"/>
+        <field name="state">ready</field>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_main_b')])]"/>
+    </record>
+
+    <record id="batch_feature_1" model="runbot.batch">
+        <field name="bundle_id" ref="bundle_feature"/>
+        <field name="state">ready</field>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_feature_a')])]"/>
+    </record>
+
+    <record id="batch_feature_2" model="runbot.batch">
+        <field name="bundle_id" ref="bundle_feature"/>
+        <field name="state">preparing</field>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_feature_b')])]"/>
+    </record>
+
+    <!-- Build params (unique fingerprint per commit_link) -->
+    <record id="params_main_a" model="runbot.build.params">
+        <field name="version_id" ref="version_18_0"/>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_main_a')])]"/>
+        <field name="create_batch_id" ref="batch_main_1"/>
+    </record>
+
+    <record id="params_main_b" model="runbot.build.params">
+        <field name="version_id" ref="version_18_0"/>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_main_b')])]"/>
+        <field name="create_batch_id" ref="batch_main_2"/>
+    </record>
+
+    <record id="params_feature_a" model="runbot.build.params">
+        <field name="version_id" ref="version_18_0"/>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_feature_a')])]"/>
+        <field name="create_batch_id" ref="batch_feature_1"/>
+    </record>
+
+    <record id="params_feature_b" model="runbot.build.params">
+        <field name="version_id" ref="version_18_0"/>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_feature_b')])]"/>
+        <field name="create_batch_id" ref="batch_feature_2"/>
+    </record>
+
+    <!-- Builds: varied states for view inspection -->
+    <record id="build_main_done_ok" model="runbot.build">
+        <field name="params_id" ref="params_main_a"/>
+        <field name="local_state">done</field>
+        <field name="local_result">ok</field>
+        <field name="host">runbot.example.local</field>
+    </record>
+
+    <record id="build_main_done_ko" model="runbot.build">
+        <field name="params_id" ref="params_main_b"/>
+        <field name="local_state">done</field>
+        <field name="local_result">ko</field>
+        <field name="host">runbot.example.local</field>
+    </record>
+
+    <record id="build_feature_running" model="runbot.build">
+        <field name="params_id" ref="params_feature_a"/>
+        <field name="local_state">running</field>
+        <field name="host">runbot.example.local</field>
+    </record>
+
+    <record id="build_feature_pending" model="runbot.build">
+        <field name="params_id" ref="params_feature_b"/>
+        <field name="local_state">pending</field>
+    </record>
+
+    <!-- Batch slots: link batches to builds via params (frontend traversal) -->
+    <record id="slot_main_1" model="runbot.batch.slot">
+        <field name="batch_id" ref="batch_main_1"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="params_id" ref="params_main_a"/>
+        <field name="build_id" ref="build_main_done_ok"/>
+        <field name="link_type">created</field>
+    </record>
+
+    <record id="slot_main_2" model="runbot.batch.slot">
+        <field name="batch_id" ref="batch_main_2"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="params_id" ref="params_main_b"/>
+        <field name="build_id" ref="build_main_done_ko"/>
+        <field name="link_type">created</field>
+    </record>
+
+    <record id="slot_feature_running" model="runbot.batch.slot">
+        <field name="batch_id" ref="batch_feature_1"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="params_id" ref="params_feature_a"/>
+        <field name="build_id" ref="build_feature_running"/>
+        <field name="link_type">created</field>
+    </record>
+
+    <record id="slot_feature_pending" model="runbot.batch.slot">
+        <field name="batch_id" ref="batch_feature_2"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="params_id" ref="params_feature_b"/>
+        <field name="build_id" ref="build_feature_pending"/>
+        <field name="link_type">created</field>
+    </record>
+
+    <!-- last_batch wiring (frontend filters by this) -->
+    <function model="runbot.bundle" name="write">
+        <value eval="[ref('bundle_18_0')]"/>
+        <value eval="{'last_batch': ref('batch_main_2')}"/>
+    </function>
+
+    <function model="runbot.bundle" name="write">
+        <value eval="[ref('bundle_feature')]"/>
+        <value eval="{'last_batch': ref('batch_feature_2')}"/>
+    </function>
+
+</odoo>


### PR DESCRIPTION
## Summary

- Nuevo módulo `runbot_attach_vscode` con un `runbot.docker_layer` reusable (xml_id `runbot_attach_vscode.docker_layer_code_server`) que instala [code-server](https://github.com/coder/code-server) sobre cualquier Dockerfile del runbot.
- Layer genérico sin auto-enchufe: el admin lo asigna a un Dockerfile target creando un layer de tipo `reference_layer` que apunta al xml_id.
- POC inicial de [tarea #67684](https://www.adhoc.inc/odoo/action-project.action_view_task/67684). Spec base: `ingadhoc/adhoc-way` → `specs/10_draft/imagen-cli-vscode-server-attacheable.md`.

## Scope de este PR

- Scaffold módulo + data XML.
- **No** incluye lógica Python — el módulo no extiende `runbot.build`/`runbot.build_config` todavía.
- **No** asigna el layer a ningún Dockerfile (decisión: manual, para no acoplar el módulo a la nomenclatura interna `adhoc_odoo_19`).

## Follow-up (mismo PR, próximos commits)

- Extender `runbot.build` con `action_open_vscode` (`docker exec` post-wake → arranca code-server en `0.0.0.0:8080` con `--auth none` para spike).
- Helper de URL `_get_vscode_url(build)` retornando `vscode-{dest}-{db_suffix}.{host}`.
- Botón "Open VS Code" en `views/build_views.xml`.
- Validar issue de `network_mode='none'` en build_config (riesgo principal flagged por la spec).

## Test plan

- [x] Install local (`odoo -d 18.0-runbot-67684 -i runbot_attach_vscode --stop-after-init --without-demo=all --no-http`) — 51 módulos cargados OK, record con xml_id creado.
- [ ] Build de runbot productivo del PR levanta verde.
- [ ] Admin asigna `reference_layer` al Dockerfile `adhoc_odoo_19` y rebuild de la imagen pasa.
- [ ] `docker run --rm odoo:adhoc_odoo_19 code-server --version` responde (validación de bake-in).