### PR TITLE
[ADD] runbot_ux: demo data for inspecting build views (task #67684)

### DIFF
--- a/runbot_ux/__manifest__.py
+++ b/runbot_ux/__manifest__.py
@@ -10,6 +10,9 @@
         "views/config_step_views.xml",
         "views/repo_views.xml",
     ],
+    "demo": [
+        "demo/runbot_ux_demo.xml",
+    ],
     "license": "AGPL-3",
     "installable": True,
 }

--- a/runbot_ux/demo/runbot_ux_demo.xml
+++ b/runbot_ux/demo/runbot_ux_demo.xml
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- Version -->
+    <record id="version_18_0" model="runbot.version">
+        <field name="name">18.0</field>
+        <field name="sequence">180</field>
+    </record>
+
+    <!-- Repo + remote (mode=disabled to keep the demo inert) -->
+    <record id="repo_acme" model="runbot.repo">
+        <field name="name">acme-addons</field>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="mode">disabled</field>
+    </record>
+
+    <record id="remote_acme" model="runbot.remote">
+        <field name="name">git@example.local:acme/acme-addons.git</field>
+        <field name="repo_id" ref="repo_acme"/>
+    </record>
+
+    <!-- Trigger (drives the "[version] All" label on builds in the frontend) -->
+    <record id="trigger_all" model="runbot.trigger">
+        <field name="name">All</field>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="repo_ids" eval="[(6, 0, [ref('repo_acme')])]"/>
+        <field name="config_id" ref="runbot.runbot_build_config_default"/>
+    </record>
+
+    <!-- Bundles: base 18.0 + a feature branch -->
+    <record id="bundle_18_0" model="runbot.bundle">
+        <field name="name">18.0</field>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="is_base" eval="True"/>
+    </record>
+
+    <record id="bundle_feature" model="runbot.bundle">
+        <field name="name">18.0-t-99999-demo</field>
+        <field name="project_id" ref="runbot.main_project"/>
+    </record>
+
+    <!-- Commits -->
+    <record id="commit_main_a" model="runbot.commit">
+        <field name="name">9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a0b</field>
+        <field name="repo_id" ref="repo_acme"/>
+        <field name="author">Alice Demo</field>
+        <field name="author_email">alice@example.local</field>
+        <field name="subject">[ADD] demo_feature: initial scaffold</field>
+        <field name="tree_hash">aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111</field>
+    </record>
+
+    <record id="commit_main_b" model="runbot.commit">
+        <field name="name">1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c</field>
+        <field name="repo_id" ref="repo_acme"/>
+        <field name="author">Bob Demo</field>
+        <field name="author_email">bob@example.local</field>
+        <field name="subject">[REF] demo_feature: prune low-value tests</field>
+        <field name="tree_hash">bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222</field>
+    </record>
+
+    <record id="commit_feature_a" model="runbot.commit">
+        <field name="name">c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0</field>
+        <field name="repo_id" ref="repo_acme"/>
+        <field name="author">Alice Demo</field>
+        <field name="author_email">alice@example.local</field>
+        <field name="subject">[IMP] demo_feature: template layer + button</field>
+        <field name="tree_hash">cccc3333cccc3333cccc3333cccc3333cccc3333</field>
+    </record>
+
+    <record id="commit_feature_b" model="runbot.commit">
+        <field name="name">d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3</field>
+        <field name="repo_id" ref="repo_acme"/>
+        <field name="author">Alice Demo</field>
+        <field name="author_email">alice@example.local</field>
+        <field name="subject">[FIX] demo_feature: handle missing host gracefully</field>
+        <field name="tree_hash">dddd4444dddd4444dddd4444dddd4444dddd4444</field>
+    </record>
+
+    <!-- Commit links -->
+    <record id="commit_link_main_a" model="runbot.commit.link">
+        <field name="commit_id" ref="commit_main_a"/>
+    </record>
+
+    <record id="commit_link_main_b" model="runbot.commit.link">
+        <field name="commit_id" ref="commit_main_b"/>
+    </record>
+
+    <record id="commit_link_feature_a" model="runbot.commit.link">
+        <field name="commit_id" ref="commit_feature_a"/>
+    </record>
+
+    <record id="commit_link_feature_b" model="runbot.commit.link">
+        <field name="commit_id" ref="commit_feature_b"/>
+    </record>
+
+    <!-- Batches (mix of states) -->
+    <record id="batch_main_1" model="runbot.batch">
+        <field name="bundle_id" ref="bundle_18_0"/>
+        <field name="state">done</field>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_main_a')])]"/>
+    </record>
+
+    <record id="batch_main_2" model="runbot.batch">
+        <field name="bundle_id" ref="bundle_18_0"/>
+        <field name="state">ready</field>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_main_b')])]"/>
+    </record>
+
+    <record id="batch_feature_1" model="runbot.batch">
+        <field name="bundle_id" ref="bundle_feature"/>
+        <field name="state">ready</field>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_feature_a')])]"/>
+    </record>
+
+    <record id="batch_feature_2" model="runbot.batch">
+        <field name="bundle_id" ref="bundle_feature"/>
+        <field name="state">preparing</field>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_feature_b')])]"/>
+    </record>
+
+    <!-- Build params (unique fingerprint per commit_link) -->
+    <record id="params_main_a" model="runbot.build.params">
+        <field name="version_id" ref="version_18_0"/>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_main_a')])]"/>
+        <field name="create_batch_id" ref="batch_main_1"/>
+    </record>
+
+    <record id="params_main_b" model="runbot.build.params">
+        <field name="version_id" ref="version_18_0"/>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_main_b')])]"/>
+        <field name="create_batch_id" ref="batch_main_2"/>
+    </record>
+
+    <record id="params_feature_a" model="runbot.build.params">
+        <field name="version_id" ref="version_18_0"/>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_feature_a')])]"/>
+        <field name="create_batch_id" ref="batch_feature_1"/>
+    </record>
+
+    <record id="params_feature_b" model="runbot.build.params">
+        <field name="version_id" ref="version_18_0"/>
+        <field name="project_id" ref="runbot.main_project"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="commit_link_ids" eval="[(6, 0, [ref('commit_link_feature_b')])]"/>
+        <field name="create_batch_id" ref="batch_feature_2"/>
+    </record>
+
+    <!-- Builds: varied states for view inspection -->
+    <record id="build_main_done_ok" model="runbot.build">
+        <field name="params_id" ref="params_main_a"/>
+        <field name="local_state">done</field>
+        <field name="local_result">ok</field>
+        <field name="host">runbot.example.local</field>
+    </record>
+
+    <record id="build_main_done_ko" model="runbot.build">
+        <field name="params_id" ref="params_main_b"/>
+        <field name="local_state">done</field>
+        <field name="local_result">ko</field>
+        <field name="host">runbot.example.local</field>
+    </record>
+
+    <record id="build_feature_running" model="runbot.build">
+        <field name="params_id" ref="params_feature_a"/>
+        <field name="local_state">running</field>
+        <field name="host">runbot.example.local</field>
+    </record>
+
+    <record id="build_feature_pending" model="runbot.build">
+        <field name="params_id" ref="params_feature_b"/>
+        <field name="local_state">pending</field>
+    </record>
+
+    <!-- Batch slots: link batches to builds via params (frontend traversal) -->
+    <record id="slot_main_1" model="runbot.batch.slot">
+        <field name="batch_id" ref="batch_main_1"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="params_id" ref="params_main_a"/>
+        <field name="build_id" ref="build_main_done_ok"/>
+        <field name="link_type">created</field>
+    </record>
+
+    <record id="slot_main_2" model="runbot.batch.slot">
+        <field name="batch_id" ref="batch_main_2"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="params_id" ref="params_main_b"/>
+        <field name="build_id" ref="build_main_done_ko"/>
+        <field name="link_type">created</field>
+    </record>
+
+    <record id="slot_feature_running" model="runbot.batch.slot">
+        <field name="batch_id" ref="batch_feature_1"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="params_id" ref="params_feature_a"/>
+        <field name="build_id" ref="build_feature_running"/>
+        <field name="link_type">created</field>
+    </record>
+
+    <record id="slot_feature_pending" model="runbot.batch.slot">
+        <field name="batch_id" ref="batch_feature_2"/>
+        <field name="trigger_id" ref="trigger_all"/>
+        <field name="params_id" ref="params_feature_b"/>
+        <field name="build_id" ref="build_feature_pending"/>
+        <field name="link_type">created</field>
+    </record>
+
+    <!-- last_batch wiring (frontend filters by this) -->
+    <function model="runbot.bundle" name="write">
+        <value eval="[ref('bundle_18_0')]"/>
+        <value eval="{'last_batch': ref('batch_main_2')}"/>
+    </function>
+
+    <function model="runbot.bundle" name="write">
+        <value eval="[ref('bundle_feature')]"/>
+        <value eval="{'last_batch': ref('batch_feature_2')}"/>
+    </function>
+
+</odoo>


### PR DESCRIPTION
Self-contained set of demo records that exercise the runbot tree end-to-end so the form and frontend views can be inspected locally without a real runbot in place. Lives in runbot_ux so it can be reused by any future runbot-ux iteration; wired up via the manifest's 'demo' key.

Records:
- 1 runbot.version (18.0).
- 1 repo + remote ('acme-addons', mode=disabled to keep the demo inert: no fetch, no clone).
- 1 trigger ('All') so builds render with a '[18.0] All' label in the frontend.
- 2 bundles: a base '18.0' (is_base, sticky=True via compute) and a feature-like branch (surfaces under the 'nosticky' filter).
- 4 commits with invented authors and SHAs.
- 4 build.params with unique commit_link_ids (distinct fingerprints).
- 4 builds covering done/ok, done/ko, running and pending states.
- 4 batches: 2 on the base bundle + 2 on the feature bundle so each build sits in its own batch (matches real runbot: every new commit on a PR opens a fresh batch).
- 4 batch.slot records wiring batches -> builds (frontend traversal, drives the per-trigger grouping in the bundle view).
- last_batch on both bundles patched via <function> after creation (chicken-and-egg: bundle exists before its batch). The feature bundle's last_batch is the newer one containing the pending build.

The pending build is intentionally left without host, so its vscode_url stays False and the 'Open VS Code' button stays hidden — matching the real runbot state machine and the guard already covered by test_action_open_vscode_blocks_when_url_missing.

Change note:
Suma demo data en runbot_ux para inspeccionar las vistas (backend form y frontend bundle/build) sin tener un runbot real montado. La estructura es la minima que reproduce un arbol completo: 1 version, 1 repo + remote inerte (mode=disabled), 1 trigger 'All', 2 bundles (base + feature), 4 commits con autores inventados, 4 build.params, 4 builds con estados variados (done/ok, done/ko, running, pending) repartidos en 4 batches (uno por build, como en runbot real) y los batch.slot que conectan todo. Util tambien para futuras iteraciones de runbot_ux.