### PR TITLE
[IMP] runbot_attach_vscode: seed code-server settings and persist its state (task #67684)

### DIFF
--- a/runbot_attach_vscode/models/runbot_build_vscode_session.py
+++ b/runbot_attach_vscode/models/runbot_build_vscode_session.py
@@ -35,6 +35,12 @@ PRESEED_MCP_SERVERS = {
         "url": "https://tuqui.com/mcp/adhoc",
     },
 }
+# Defaults seeded into code-server's settings.json on a user's first session.
+VSCODE_USER_SETTINGS = {
+    "workbench.colorTheme": "Default Dark Modern",
+    "workbench.startupEditor": "none",
+    "remote.autoForwardPorts": False,
+}
 
 
 class RunbotBuildVscodeSession(models.Model):
@@ -185,8 +191,15 @@ class RunbotBuildVscodeSession(models.Model):
         auth_dir = self._auth_dir()
         # We create these folders as the runbot user, so they end up owned by
         # the same user the container runs as.
-        for sub in (".claude", ".codex", ".gemini"):
+        for sub in (".claude", ".codex", ".gemini", ".local"):
             os.makedirs(os.path.join(auth_dir, sub), exist_ok=True)
+        # Seed the settings once; later sessions keep what the user changed.
+        settings_dir = os.path.join(auth_dir, ".local", "share", "code-server", "User")
+        settings_json = os.path.join(settings_dir, "settings.json")
+        if not os.path.exists(settings_json):
+            os.makedirs(settings_dir, exist_ok=True)
+            with open(settings_json, "w") as f:
+                json.dump(VSCODE_USER_SETTINGS, f, indent=4)
         # Claude Code keeps the logged-in account in ~/.claude.json (next to the
         # .claude folder, not inside it). Pre-seed the MCP servers here so the
         # user only needs to pick one in /mcp and authenticate.
@@ -226,6 +239,8 @@ class RunbotBuildVscodeSession(models.Model):
             f"{os.path.join(auth_dir, '.codex')}:{CONTAINER_HOME}/.codex:rw",
             "-v",
             f"{os.path.join(auth_dir, '.gemini')}:{CONTAINER_HOME}/.gemini:rw",
+            "-v",
+            f"{os.path.join(auth_dir, '.local')}:{CONTAINER_HOME}/.local:rw",
         ]
         # Mirror the repo sources runbot mounts on the build's own container,
         # so the side container sees the same /data/build/<repo>/ layout.


### PR DESCRIPTION
## Qué hace

Cuando arranca una sesión de VS Code (code-server) en una build:

- Crea y monta `~/.local` (`rw`) en el container, junto a `.claude`/`.codex`/`.gemini`. Así code-server persiste su estado (settings, extensiones) entre sesiones y builds del mismo usuario.
- Siembra `~/.local/share/code-server/User/settings.json` la primera vez (no pisa ediciones posteriores del usuario, mismo criterio que el preseed de MCP servers) con defaults:

```json
{
    "workbench.colorTheme": "Default Dark Modern",
    "workbench.startupEditor": "none",
    "remote.autoForwardPorts": false
}
```

## Por qué

El editor arrancaba en tema claro, abría el tab de bienvenida y ofrecía auto-forward de puertos en cada sesión. Estos defaults dan un arranque consistente y, al persistir `~/.local`, lo que el usuario ajuste se mantiene.

## Test plan

- Abrir una sesión de VS Code sobre una build con el layer code-server.
- Verificar: arranca en tema oscuro (Default Dark Modern), sin tab de bienvenida.
- Editar un setting desde el editor, cerrar y reabrir la sesión → el cambio persiste.