### PR TITLE
[IMP] runbot_attach_vscode: install VS Code extensions on session start (task #67684)

### DIFF
--- a/runbot_attach_vscode/README.rst
+++ b/runbot_attach_vscode/README.rst
@@ -3,12 +3,13 @@ Runbot Attach VS Code
 =====================
 
 Bakes `code-server <https://github.com/coder/code-server>`_ (VS Code in
-the browser) plus a curated set of AI coding CLIs (Claude Code, OpenAI
-Codex, Google Gemini, OpenCode) into runbot Dockerfiles via a reusable
+the browser) into runbot Dockerfiles via a reusable
 ``runbot.docker_layer``. Each wakeable ``runbot.build`` whose Dockerfile
 attaches that layer exposes an *Open VS Code* button that opens, **per
 user**, a dedicated code-server side container attached to the build —
-with the AI CLIs ready to use from its integrated terminal.
+with the AI coding CLIs (Claude Code, OpenAI Codex, Google Gemini,
+OpenCode), which ship in the base image, ready to use from its
+integrated terminal.
 
 Per-user isolation
 ==================
@@ -101,12 +102,11 @@ The URL helper is a no-op when the build's Dockerfile does not attach
 the code-server reference layer (see ``_has_vscode_layer``), so builds
 on unrelated Dockerfiles keep working unchanged.
 
-AI CLIs baked into the layer
-============================
+AI CLIs
+=======
 
-On top of code-server, the layer installs Node 20 (from NodeSource) and
-the following npm-distributed CLIs, available globally in the build
-container:
+The build container ships these AI coding CLIs from the base image,
+available globally in the code-server terminal:
 
 * ``claude`` — `Claude Code <https://docs.claude.com/en/docs/claude-code/overview>`_
   (``@anthropic-ai/claude-code``).
@@ -116,9 +116,8 @@ container:
   (``@google/gemini-cli``).
 * ``opencode`` — `OpenCode <https://opencode.ai/>`_ (``opencode-ai``).
 
-All four are installed in the same ``RUN`` as code-server to keep the
-image layer count low. Image cost: ~1.1 GB of ``/usr/lib/node_modules``
-on top of the ~430 MB code-server already adds.
+This layer only installs code-server; the CLIs and their Node runtime
+live in the base image.
 
 The tools come without any login — each user signs in from the
 code-server terminal the first time. Because each user's login folders

--- a/runbot_attach_vscode/README.rst
+++ b/runbot_attach_vscode/README.rst
@@ -140,11 +140,9 @@ System parameters:
     Host root for per-user login folders. Default:
     ``~/.adhoc-runbot-auth`` of the runbot user.
 
-The pinned code-server version lives in the layer's ``values`` field
-(``CODE_SERVER_VERSION``, default ``4.96.4``). To override per
-Dockerfile, set the ``values`` JSON of the consuming
-``reference_layer`` — see ``runbot.docker_layer._render_template`` for
-the merge order (base + source + caller).
+The layer installs the latest code-server release (the install script
+is run without a version pin), so a rebuilt image picks up new
+versions automatically.
 
 Limitations
 ===========

--- a/runbot_attach_vscode/data/runbot_docker_layer.xml
+++ b/runbot_attach_vscode/data/runbot_docker_layer.xml
@@ -8,10 +8,10 @@
     <record id="docker_layer_code_server" model="runbot.docker_layer">
         <field name="name">code_server</field>
         <field name="sequence">200</field>
-        <field name="layer_type">template</field>
-        <field name="content"># Layer: code-server v{CODE_SERVER_VERSION} + AI CLIs (runbot_attach_vscode)
+        <field name="layer_type">raw</field>
+        <field name="content"># Layer: code-server (latest) + AI CLIs (runbot_attach_vscode)
 USER root
-RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version {CODE_SERVER_VERSION} \
+RUN curl -fsSL https://code-server.dev/install.sh | sh \
     &amp;&amp; curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     &amp;&amp; apt-get install -y --no-install-recommends nodejs \
     &amp;&amp; npm install -g --silent \
@@ -21,7 +21,6 @@ RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version {CODE_SER
         opencode-ai \
     &amp;&amp; rm -rf /var/lib/apt/lists/* /root/.npm /tmp/*
 USER runbot</field>
-        <field name="values" eval="{'CODE_SERVER_VERSION': '4.96.4'}"/>
     </record>
 
 </odoo>

--- a/runbot_attach_vscode/data/runbot_docker_layer.xml
+++ b/runbot_attach_vscode/data/runbot_docker_layer.xml
@@ -1,25 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <!-- Bake-in: code-server (web editor) + AI CLIs (Claude Code, OpenCode,
-         OpenAI Codex, Google Gemini). Installed as a single RUN to keep
-         image-layer count down. Node 20 via NodeSource is required by the
-         three npm-distributed CLIs. -->
+    <!-- Bake-in: code-server (web editor). The AI CLIs and Node now live in
+         the base image, so this layer only installs code-server. -->
     <record id="docker_layer_code_server" model="runbot.docker_layer">
         <field name="name">code_server</field>
         <field name="sequence">200</field>
         <field name="layer_type">raw</field>
-        <field name="content"># Layer: code-server (latest) + AI CLIs (runbot_attach_vscode)
+        <field name="content"># Layer: code-server (latest) (runbot_attach_vscode)
 USER root
 RUN curl -fsSL https://code-server.dev/install.sh | sh \
-    &amp;&amp; curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    &amp;&amp; apt-get install -y --no-install-recommends nodejs \
-    &amp;&amp; npm install -g --silent \
-        @anthropic-ai/claude-code \
-        @openai/codex \
-        @google/gemini-cli \
-        opencode-ai \
-    &amp;&amp; rm -rf /var/lib/apt/lists/* /root/.npm /tmp/*
+    &amp;&amp; rm -rf /var/lib/apt/lists/* /tmp/*
 USER runbot</field>
     </record>
 

--- a/runbot_attach_vscode/models/runbot_build_vscode_session.py
+++ b/runbot_attach_vscode/models/runbot_build_vscode_session.py
@@ -261,6 +261,7 @@ class RunbotBuildVscodeSession(models.Model):
         # Install the extensions, then hand the process over to code-server
         # (exec keeps it as PID 1 so --rm and docker stop still work).
         startup = "".join(f'code-server --install-extension "{ext}" || true\n' for ext in VSCODE_EXTENSIONS)
+        startup += "adhoc-way init || true\n"
         startup += f"exec code-server --bind-addr 0.0.0.0:{VSCODE_CONTAINER_PORT} --auth none /data/build"
         cmd += [image_tag, "bash", "-c", startup]
         try:

--- a/runbot_attach_vscode/models/runbot_build_vscode_session.py
+++ b/runbot_attach_vscode/models/runbot_build_vscode_session.py
@@ -45,6 +45,7 @@ VSCODE_USER_SETTINGS = {
 # ~/.local, so reinstalling on later sessions is a quick no-op.
 VSCODE_EXTENSIONS = [
     "Anthropic.claude-code",
+    "zaaack.markdown-editor",
 ]
 
 

--- a/runbot_attach_vscode/models/runbot_build_vscode_session.py
+++ b/runbot_attach_vscode/models/runbot_build_vscode_session.py
@@ -197,7 +197,7 @@ class RunbotBuildVscodeSession(models.Model):
         auth_dir = self._auth_dir()
         # We create these folders as the runbot user, so they end up owned by
         # the same user the container runs as.
-        for sub in (".claude", ".codex", ".gemini", ".local"):
+        for sub in (".claude", ".codex", ".gemini", ".local", ".adhoc"):
             os.makedirs(os.path.join(auth_dir, sub), exist_ok=True)
         # Seed the settings once; later sessions keep what the user changed.
         settings_dir = os.path.join(auth_dir, ".local", "share", "code-server", "User")
@@ -247,6 +247,8 @@ class RunbotBuildVscodeSession(models.Model):
             f"{os.path.join(auth_dir, '.gemini')}:{CONTAINER_HOME}/.gemini:rw",
             "-v",
             f"{os.path.join(auth_dir, '.local')}:{CONTAINER_HOME}/.local:rw",
+            "-v",
+            f"{os.path.join(auth_dir, '.adhoc')}:{CONTAINER_HOME}/.adhoc:rw",
         ]
         # Mirror the repo sources runbot mounts on the build's own container,
         # so the side container sees the same /data/build/<repo>/ layout.

--- a/runbot_attach_vscode/models/runbot_build_vscode_session.py
+++ b/runbot_attach_vscode/models/runbot_build_vscode_session.py
@@ -40,6 +40,10 @@ VSCODE_USER_SETTINGS = {
     "workbench.colorTheme": "Default Dark Modern",
     "workbench.startupEditor": "none",
     "remote.autoForwardPorts": False,
+    "security.workspace.trust.enabled": False,
+    "security.workspace.trust.banner": "never",
+    "security.workspace.trust.startupPrompt": "never",
+    "security.workspace.trust.untrustedFiles": "open",
 }
 # Extensions installed before code-server starts. They land in the mounted
 # ~/.local, so reinstalling on later sessions is a quick no-op.

--- a/runbot_attach_vscode/models/runbot_build_vscode_session.py
+++ b/runbot_attach_vscode/models/runbot_build_vscode_session.py
@@ -41,6 +41,11 @@ VSCODE_USER_SETTINGS = {
     "workbench.startupEditor": "none",
     "remote.autoForwardPorts": False,
 }
+# Extensions installed before code-server starts. They land in the mounted
+# ~/.local, so reinstalling on later sessions is a quick no-op.
+VSCODE_EXTENSIONS = [
+    "Anthropic.claude-code",
+]
 
 
 class RunbotBuildVscodeSession(models.Model):
@@ -246,15 +251,11 @@ class RunbotBuildVscodeSession(models.Model):
         # so the side container sees the same /data/build/<repo>/ layout.
         for src, dst in self._build_source_mounts():
             cmd += ["-v", f"{src}:{dst}:ro"]
-        cmd += [
-            image_tag,
-            "code-server",
-            "--bind-addr",
-            f"0.0.0.0:{VSCODE_CONTAINER_PORT}",
-            "--auth",
-            "none",
-            "/data/build",
-        ]
+        # Install the extensions, then hand the process over to code-server
+        # (exec keeps it as PID 1 so --rm and docker stop still work).
+        startup = "".join(f'code-server --install-extension "{ext}" || true\n' for ext in VSCODE_EXTENSIONS)
+        startup += f"exec code-server --bind-addr 0.0.0.0:{VSCODE_CONTAINER_PORT} --auth none /data/build"
+        cmd += [image_tag, "bash", "-c", startup]
         try:
             result = subprocess.run(
                 cmd,


### PR DESCRIPTION
## Qué hace

Antes de lanzar code-server, la sesión instala las extensiones declaradas en `VSCODE_EXTENSIONS` (hoy `Anthropic.claude-code` y `zaaack.markdown-editor`) y recién entonces hace `exec code-server …`.

El arranque pasa de un comando directo a `bash -c "<script>"`:

```sh
code-server --install-extension "Anthropic.claude-code" || true
code-server --install-extension "zaaack.markdown-editor" || true
exec code-server --bind-addr 0.0.0.0:8071 --auth none /data/build
```

## Por qué / detalles

- **`exec`**: code-server queda como PID 1, así `docker run --rm` y el `docker stop` del kill siguen funcionando igual.
- **`|| true`**: code-server usa Open VSX por defecto; si una extensión no está disponible, no rompe el arranque.
- **Persistencia**: las extensiones caen en `~/.local/share/code-server/extensions`, que se monta y persiste por usuario, así que en sesiones siguientes el reinstall es un no-op rápido.

Construye sobre el cambio que montó `~/.local` (ya en 18.0).

## Test plan

- Abrir una sesión de VS Code sobre una build con el layer code-server.
- Verificar que las extensiones quedan instaladas al abrir el editor.
- Cerrar y reabrir la sesión → siguen instaladas (no se vuelven a descargar).