### PR TITLE
[IMP] runbot_attach_vscode: auto-open Claude Code in the panel on startup (task #67684)

### DIFF
--- a/runbot_attach_vscode/models/runbot_build_vscode_session.py
+++ b/runbot_attach_vscode/models/runbot_build_vscode_session.py
@@ -44,12 +44,19 @@ VSCODE_USER_SETTINGS = {
     "security.workspace.trust.banner": "never",
     "security.workspace.trust.startupPrompt": "never",
     "security.workspace.trust.untrustedFiles": "open",
+    # Open Claude Code in the bottom panel on startup. The view has no native
+    # open-on-startup setting, so auto-run-command fires its command for us.
+    "claudeCode.preferredLocation": "panel",
+    "auto-run-command.rules": [
+        {"condition": "always", "command": "claude-vscode.editor.openLast"},
+    ],
 }
 # Extensions installed before code-server starts. They land in the mounted
 # ~/.local, so reinstalling on later sessions is a quick no-op.
 VSCODE_EXTENSIONS = [
     "Anthropic.claude-code",
     "zaaack.markdown-editor",
+    "synedra.auto-run-command",
 ]
 
 


### PR DESCRIPTION
## Qué hace

Al abrir el VS Code web, abre automáticamente la extensión Claude Code en el panel inferior.

Como una ``view`` de extensión (no-chat) no tiene setting nativo de "abrir al iniciar", se suma la extensión ``synedra.auto-run-command`` (disponible en Open VSX) y se configura para disparar el comando de apertura al arrancar:

* ``claudeCode.preferredLocation: panel``
* ``auto-run-command.rules`` → ``{condition: always, command: claude-vscode.editor.openLast}``

``editor.openLast`` es la acción canónica "Open Claude Code" del extension (la del botón ✻ de la status bar) y respeta ``preferredLocation``, por eso abre en el panel.

## Estado / dependencia

Apilado sobre #54 — hasta que ese se mergee, este PR incluye también sus commits. Se separó del #54 a propósito porque el auto-open todavía está en validación.

## Test plan

- Abrir una sesión de VS Code sobre una build con el layer code-server (con ``settings.json`` sembrado de cero).
- Verificar que, unos segundos después de cargar el editor, Claude Code abre solo en el panel inferior.