### PR TITLE
[ADD] runbot_token_auth: shared signed access token

### DIFF
--- a/runbot_attach_vscode/__manifest__.py
+++ b/runbot_attach_vscode/__manifest__.py
@@ -5,7 +5,7 @@
     "website": "https://www.adhoc.com.ar",
     "category": "Website",
     "version": "18.0.2.2.0",
-    "depends": ["runbot"],
+    "depends": ["runbot", "runbot_token_auth"],
     "data": [
         "security/ir.model.access.csv",
         "data/ir_config_parameter.xml",

--- a/runbot_attach_vscode/controllers/main.py
+++ b/runbot_attach_vscode/controllers/main.py
@@ -1,6 +1,3 @@
-import base64
-import hashlib
-import hmac
 import logging
 import time
 
@@ -22,17 +19,8 @@ class VsCodeController(http.Controller):
     On every request to that address, nginx calls `auth_check` to make sure
     the token is valid, not expired, for this build, and belongs to the user
     who owns the address — so one user's token can never open another user's
-    container.
+    container. The token is built and checked by `runbot.token.signer`.
     """
-
-    @staticmethod
-    def _vscode_secret():
-        param = request.env["ir.config_parameter"].sudo().get_param("database.secret")
-        if not param:
-            # database.secret may not be set yet; fall back to database.uuid so
-            # we sign and check tokens with the same key even after a restart.
-            param = request.env["ir.config_parameter"].sudo().get_param("database.uuid", "")
-        return (param or "").encode()
 
     @staticmethod
     def _cookie_name(build_id):
@@ -40,46 +28,6 @@ class VsCodeController(http.Controller):
         user opening VS Code on a second build does not overwrite the first
         build's token."""
         return f"vscode_token_{build_id}"
-
-    @staticmethod
-    def _b64(raw):
-        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
-
-    @staticmethod
-    def _unb64(text):
-        return base64.urlsafe_b64decode(text + "=" * (-len(text) % 4))
-
-    @classmethod
-    def _make_token(cls, build_id, user_id, exp):
-        payload = f"{int(build_id)}|{int(user_id)}|{int(exp)}".encode()
-        sig = hmac.new(cls._vscode_secret(), payload, hashlib.sha256).digest()
-        # Encode the two parts separately and join with a dot. The dot is safe
-        # as a separator because urlsafe base64 never produces one, so the
-        # signature's raw bytes can't be mistaken for it.
-        return f"{cls._b64(payload)}.{cls._b64(sig)}"
-
-    @classmethod
-    def _verify_token(cls, token, build_id, user_id=None):
-        """Check the token's signature and expiry, and that it is for this
-        build. When `user_id` is given, also check the token belongs to that
-        user."""
-        try:
-            body, mac = token.split(".", 1)
-            payload = cls._unb64(body)
-            sig = cls._unb64(mac)
-            expected = hmac.new(cls._vscode_secret(), payload, hashlib.sha256).digest()
-            if not hmac.compare_digest(sig, expected):
-                return False
-            tok_build, tok_user, exp = payload.decode().split("|")
-            if int(tok_build) != int(build_id):
-                return False
-            if user_id is not None and int(tok_user) != int(user_id):
-                return False
-            if int(exp) < int(time.time()):
-                return False
-            return True
-        except Exception:
-            return False
 
     @http.route(
         ["/runbot/vscode/<int:build_id>"],
@@ -120,7 +68,7 @@ class VsCodeController(http.Controller):
         # block would land on the wrong host. Revisit if runbot becomes multi-host.
         request.env["runbot.runbot"].sudo()._reload_nginx()
         exp = int(time.time()) + TOKEN_TTL_SECONDS
-        token = self._make_token(build.id, request.env.user.id, exp)
+        token = request.env["runbot.token.signer"]._make_token(build.id, request.env.user.id, exp)
         response = request.redirect(build._vscode_session_url(session), code=302, local=False)
         # This token proves who the user is. We hand it out here (on Odoo's
         # host) but nginx checks it on the VS Code subdomain, so we tie it to
@@ -159,7 +107,12 @@ class VsCodeController(http.Controller):
             expected_user_id = int(str(user).split("-", 1)[0])
         except (ValueError, TypeError):
             return Response(status=401)
-        if not self._verify_token(token, build, expected_user_id):
+        # parts are (build_id, user_id, exp); the signer already checked the
+        # signature and expiry, here we check the token is for this build and user.
+        parts = request.env["runbot.token.signer"]._verify_token(token)
+        if not parts or len(parts) != 3:
+            return Response(status=401)
+        if int(parts[0]) != int(build) or int(parts[1]) != expected_user_id:
             return Response(status=401)
         session = (
             request.env["runbot.build.vscode.session"]

--- a/runbot_attach_vscode/tests/test_runbot_attach_vscode.py
+++ b/runbot_attach_vscode/tests/test_runbot_attach_vscode.py
@@ -3,12 +3,10 @@ from unittest.mock import patch
 
 from odoo.tests import TransactionCase, tagged
 
-from ..controllers.main import VsCodeController
-
 
 @tagged("-at_install", "post_install")
 class TestRunbotAttachVscode(TransactionCase):
-    """code-server layer, vscode availability, per-user sessions and auth."""
+    """code-server layer, vscode availability and per-user sessions."""
 
     @classmethod
     def setUpClass(cls):
@@ -145,36 +143,6 @@ class TestRunbotAttachVscode(TransactionCase):
             sessions[1].container_name,
             "each user's container is isolated",
         )
-
-    # --- auth (the security-critical property) -----------------------------
-
-    def test_token_verification(self):
-        """Token must be rejected for the wrong user, the wrong build, or when
-        expired, and accepted for the right (build, user) before expiry."""
-        with patch.object(VsCodeController, "_vscode_secret", staticmethod(lambda: b"testkey")):
-            token = VsCodeController._make_token(build_id=7, user_id=self.user_a.id, exp=2**31)
-            self.assertTrue(VsCodeController._verify_token(token, 7, self.user_a.id))
-            # signed for user A, must not validate for user B
-            self.assertFalse(VsCodeController._verify_token(token, 7, self.user_b.id))
-            # wrong build
-            self.assertFalse(VsCodeController._verify_token(token, 8, self.user_a.id))
-            # also valid when the user is not checked (build-only)
-            self.assertTrue(VsCodeController._verify_token(token, 7))
-            # expired token
-            expired = VsCodeController._make_token(build_id=7, user_id=self.user_a.id, exp=1)
-            self.assertFalse(VsCodeController._verify_token(expired, 7, self.user_a.id))
-
-    def test_token_roundtrip_is_stable(self):
-        """Every freshly made token must verify. Guards against signature bytes
-        being mistaken for the separator (the dot)."""
-        with patch.object(VsCodeController, "_vscode_secret", staticmethod(lambda: b"testkey")):
-            for build_id in range(1, 60):
-                for user_id in range(1, 5):
-                    token = VsCodeController._make_token(build_id, user_id, 2**31)
-                    self.assertTrue(
-                        VsCodeController._verify_token(token, build_id, user_id),
-                        f"token for build={build_id} user={user_id} failed to verify",
-                    )
 
     # --- teardown ----------------------------------------------------------
 

--- a/runbot_token_auth/__init__.py
+++ b/runbot_token_auth/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/runbot_token_auth/__manifest__.py
+++ b/runbot_token_auth/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "Runbot Token Auth",
+    "summary": "Shared signed-token auth for runbot per-user container modules",
+    "author": "ADHOC SA",
+    "website": "https://www.adhoc.com.ar",
+    "category": "Website",
+    "version": "18.0.1.0.0",
+    "depends": ["base"],
+    "license": "AGPL-3",
+    "installable": True,
+}

--- a/runbot_token_auth/models/__init__.py
+++ b/runbot_token_auth/models/__init__.py
@@ -1,0 +1,1 @@
+from . import runbot_token_signer

--- a/runbot_token_auth/models/runbot_token_signer.py
+++ b/runbot_token_auth/models/runbot_token_signer.py
@@ -1,0 +1,60 @@
+import base64
+import hashlib
+import hmac
+import time
+
+from odoo import models
+
+
+class RunbotTokenSigner(models.AbstractModel):
+    """Signed access tokens shared by the runbot per-user container modules.
+
+    A token is `<payload>.<signature>`, both urlsafe base64. The payload is the
+    given parts joined by `|`; the signature is an HMAC over it with the database
+    secret. By convention the last part is the expiry timestamp. Each module
+    decides which parts to put in and check (e.g. build+user+exp, or user+exp);
+    this model only signs them and validates the signature and expiry.
+    """
+
+    _name = "runbot.token.signer"
+    _description = "Runbot signed access token"
+
+    def _secret(self):
+        """Key used to sign tokens: the database secret, or the database uuid as
+        a fallback so the key survives a restart even if the secret is unset."""
+        get_param = self.env["ir.config_parameter"].sudo().get_param
+        return (get_param("database.secret") or get_param("database.uuid", "")).encode()
+
+    @staticmethod
+    def _b64(raw):
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    @staticmethod
+    def _unb64(text):
+        return base64.urlsafe_b64decode(text + "=" * (-len(text) % 4))
+
+    def _make_token(self, *parts):
+        """Sign a token from `parts` (integers); the last part is the expiry."""
+        payload = "|".join(str(int(p)) for p in parts).encode()
+        sig = hmac.new(self._secret(), payload, hashlib.sha256).digest()
+        # The dot is a safe separator: urlsafe base64 never produces one, so the
+        # signature's bytes can't be mistaken for it.
+        return f"{self._b64(payload)}.{self._b64(sig)}"
+
+    def _verify_token(self, token):
+        """Return the token's parts (list of strings) when the signature is valid
+        and it has not expired; otherwise None. The caller checks the parts
+        (build, user, ...) are the ones it expects."""
+        try:
+            body, mac = token.split(".", 1)
+            payload = self._unb64(body)
+            sig = self._unb64(mac)
+            expected = hmac.new(self._secret(), payload, hashlib.sha256).digest()
+            if not hmac.compare_digest(sig, expected):
+                return None
+            parts = payload.decode().split("|")
+            if int(parts[-1]) < int(time.time()):
+                return None
+            return parts
+        except Exception:
+            return None

--- a/runbot_token_auth/tests/__init__.py
+++ b/runbot_token_auth/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_runbot_token_auth

--- a/runbot_token_auth/tests/test_runbot_token_auth.py
+++ b/runbot_token_auth/tests/test_runbot_token_auth.py
@@ -1,0 +1,33 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestRunbotTokenAuth(TransactionCase):
+    """Signed access tokens: signature validity, tampering and expiry."""
+
+    def test_token_verification(self):
+        """A token returns its signed parts before expiry (so the caller can
+        check build and user), and is rejected when tampered with or expired."""
+        signer = self.env["runbot.token.signer"]
+        token = signer._make_token(7, 42, 2**31)
+        self.assertEqual(signer._verify_token(token), ["7", "42", str(2**31)])
+        # a token whose payload and signature don't match must not verify: take
+        # this token's payload but another token's signature.
+        other = signer._make_token(8, 42, 2**31)
+        forged = token.split(".")[0] + "." + other.split(".")[1]
+        self.assertIsNone(signer._verify_token(forged))
+        # expired token must not verify
+        self.assertIsNone(signer._verify_token(signer._make_token(7, 42, 1)))
+
+    def test_token_roundtrip_is_stable(self):
+        """Every freshly made token returns the same parts. Guards against
+        signature bytes being mistaken for the separator (the dot)."""
+        signer = self.env["runbot.token.signer"]
+        for build_id in range(1, 60):
+            for user_id in range(1, 5):
+                parts = signer._verify_token(signer._make_token(build_id, user_id, 2**31))
+                self.assertEqual(
+                    parts,
+                    [str(build_id), str(user_id), str(2**31)],
+                    f"token for build={build_id} user={user_id} failed to verify",
+                )


### PR DESCRIPTION
New base module with the runbot.token.signer AbstractModel: HMAC sign and verify of access tokens (payload parts joined by '|', last part is the expiry), so the runbot per-user container modules share one implementation instead of duplicating the crypto.

[REF] runbot_attach_vscode: use runbot.token.signer instead of its own token helpers. The controller signs and verifies through env['runbot.token.signer'] and checks the build and user parts itself. Same secret and same token format, so existing cookies keep working. Tests updated to exercise the signer.