### PR TITLE
[ADD] runbot_opencode: personal per-user OpenCode workspace

### DIFF
--- a/runbot_attach_vscode/models/runbot_build_vscode_session.py
+++ b/runbot_attach_vscode/models/runbot_build_vscode_session.py
@@ -2,7 +2,6 @@ import http.client
 import json
 import logging
 import os
-import re
 import socket
 import subprocess
 import time
@@ -97,15 +96,9 @@ class RunbotBuildVscodeSession(models.Model):
 
     @api.depends("user_id")
     def _compute_user_key(self):
+        signer = self.env["runbot.token.signer"]
         for session in self:
-            user = session.user_id
-            if not user:
-                session.user_key = False
-                continue
-            # Keep only the part before the `@` so email logins stay short.
-            local_part = (user.login or "").split("@")[0]
-            login_slug = re.sub(r"[^a-z0-9]+", "-", local_part.lower()).strip("-")
-            session.user_key = f"{user.id}-{login_slug}" if login_slug else str(user.id)
+            session.user_key = signer._user_key(session.user_id) if session.user_id else False
 
     @api.depends("build_id.dest", "user_key")
     def _compute_container_name(self):

--- a/runbot_opencode/__init__.py
+++ b/runbot_opencode/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/runbot_opencode/__manifest__.py
+++ b/runbot_opencode/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    "name": "Runbot OpenCode",
+    "summary": "Personal OpenCode workspace per user, always on the latest OBA sources",
+    "author": "ADHOC SA",
+    "website": "https://www.adhoc.com.ar",
+    "category": "Website",
+    "version": "18.0.1.0.0",
+    # runbot_token_auth provides the shared signed-token auth (runbot.token.signer).
+    "depends": ["runbot", "runbot_token_auth"],
+    "data": [
+        "security/ir.model.access.csv",
+        "data/ir_config_parameter.xml",
+        "data/ir_cron_data.xml",
+        "views/runbot_opencode_workspace_views.xml",
+        "views/runbot_opencode_bundle_views.xml",
+        "views/runbot_frontend_templates.xml",
+        "views/runbot_nginx.xml",
+    ],
+    "license": "AGPL-3",
+    "installable": True,
+}

--- a/runbot_opencode/controllers/__init__.py
+++ b/runbot_opencode/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/runbot_opencode/controllers/main.py
+++ b/runbot_opencode/controllers/main.py
@@ -1,0 +1,98 @@
+import logging
+import time
+
+from odoo import _, http
+from odoo.exceptions import UserError
+from odoo.http import Response, request
+
+_logger = logging.getLogger(__name__)
+
+TOKEN_TTL_SECONDS = 8 * 3600
+COOKIE_NAME = "opencode_token"
+
+
+class OpencodeController(http.Controller):
+    """Opens a user's OpenCode workspace and checks their access token.
+
+    "OpenCode" in the user menu hits `/runbot/opencode`, which finds or creates
+    the user's workspace, hands the browser a signed token, and sends them to
+    their personal address `opencode-<user_key>.<host>`. nginx then calls
+    `auth_check` before every request to that address, so one user's token can
+    never open another user's workspace. The token is built and checked by
+    `runbot.token.signer`.
+    """
+
+    @http.route(
+        ["/runbot/opencode"],
+        type="http",
+        auth="user",
+        website=True,
+        sitemap=False,
+    )
+    def open_opencode(self):
+        """Find or create the user's workspace, start its container, set the
+        access token, and send the browser to their personal address."""
+        if not request.env.user._is_internal():
+            return request.not_found()
+        host = request.env["runbot.host"]._get_current_name()
+        try:
+            workspace = request.env["runbot.opencode.workspace"].sudo()._ensure_workspace(request.env.user)
+        except UserError as exc:
+            return request.render(
+                "http_routing.http_error",
+                {"status_code": _("OpenCode"), "status_message": exc.args[0]},
+            )
+        # Reload nginx so the new server block is live before the redirect
+        # fires. Single-host assumption.
+        request.env["runbot.runbot"].sudo()._reload_nginx()
+        exp = int(time.time()) + TOKEN_TTL_SECONDS
+        token = request.env["runbot.token.signer"]._make_token(request.env.user.id, exp)
+        # Same address the container is told it serves at (see _get_public_url).
+        url = workspace._get_public_url()
+        response = request.redirect(url, code=302, local=False)
+        # We hand the token out here (on Odoo's host) but nginx checks it on the
+        # OpenCode subdomain, so tie it to `host` to make the browser send it.
+        response.set_cookie(
+            COOKIE_NAME,
+            token,
+            max_age=TOKEN_TTL_SECONDS,
+            domain=host,
+            secure=True,
+            httponly=True,
+            samesite="Lax",
+            path="/",
+        )
+        return response
+
+    @http.route(
+        ["/runbot/opencode/auth_check"],
+        type="http",
+        auth="public",
+        csrf=False,
+        sitemap=False,
+    )
+    def auth_check(self, user=None):
+        """Called by nginx before every request to an OpenCode address. Returns
+        200 only when the token is valid and belongs to the user who owns the
+        address (`user` is the `<id>-<slug>` key). Also marks the workspace as
+        recently used so the cleanup job leaves it alone."""
+        if not user:
+            return Response(status=401)
+        token = request.httprequest.cookies.get(COOKIE_NAME, "")
+        if not token:
+            return Response(status=401)
+        try:
+            expected_user_id = int(str(user).split("-", 1)[0])
+        except (ValueError, TypeError):
+            return Response(status=401)
+        # parts are (user_id, exp); the signer already checked the signature and
+        # expiry, here we check the token belongs to the user owning the address.
+        parts = request.env["runbot.token.signer"]._verify_token(token)
+        if not parts or len(parts) != 2 or int(parts[0]) != expected_user_id:
+            return Response(status=401)
+        workspace = (
+            request.env["runbot.opencode.workspace"].sudo().search([("user_id", "=", expected_user_id)], limit=1)
+        )
+        if workspace:
+            workspace.touch()
+        return Response(status=200)

--- a/runbot_opencode/data/ir_config_parameter.xml
+++ b/runbot_opencode/data/ir_config_parameter.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- Host path of the oba-project checkout, kept in sync outside this module. -->
+    <record id="ir_config_parameter_oba_project_path" model="ir.config_parameter">
+        <field name="key">runbot_opencode.oba_project_path</field>
+        <field name="value">/home/runbot/sync-repos/oba-project</field>
+    </record>
+
+    <!-- Stop a workspace's container after this many idle hours. -->
+    <record id="ir_config_parameter_idle_timeout_hours" model="ir.config_parameter">
+        <field name="key">runbot_opencode.idle_timeout_hours</field>
+        <field name="value">8</field>
+    </record>
+
+    <!-- URL scheme (http/https) for the personal address. -->
+    <record id="ir_config_parameter_scheme" model="ir.config_parameter">
+        <field name="key">runbot_opencode.scheme</field>
+        <field name="value">https</field>
+    </record>
+
+    <!-- OpenCode container image, with the agent tooling (opencode, adhoc-way). -->
+    <record id="ir_config_parameter_image" model="ir.config_parameter">
+        <field name="key">runbot_opencode.image</field>
+        <field name="value">docker.io/adhoc/ops-tools:open-code-server-latest</field>
+    </record>
+
+</odoo>

--- a/runbot_opencode/data/ir_cron_data.xml
+++ b/runbot_opencode/data/ir_cron_data.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Stops OpenCode containers nobody has used for a while (removes the
+         container; the user's files stay on the host). -->
+    <record id="ir_cron_close_unused_workspaces" model="ir.cron">
+        <field name="name">Runbot: close unused OpenCode workspaces</field>
+        <field name="model_id" ref="model_runbot_opencode_workspace"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_close_unused_workspaces()</field>
+        <field name="interval_number">30</field>
+        <field name="interval_type">minutes</field>
+        <field name="active" eval="True"/>
+    </record>
+
+</odoo>

--- a/runbot_opencode/models/__init__.py
+++ b/runbot_opencode/models/__init__.py
@@ -1,0 +1,2 @@
+from . import runbot_opencode_bundle
+from . import runbot_opencode_workspace

--- a/runbot_opencode/models/runbot_opencode_bundle.py
+++ b/runbot_opencode/models/runbot_opencode_bundle.py
@@ -1,0 +1,51 @@
+from odoo import fields, models
+
+
+class RunbotOpencodeBundle(models.Model):
+    """A runbot bundle exposed in the OpenCode workspaces.
+
+    Each record is one bundle whose latest finished build is mounted under
+    `dir_name` in every user's workspace.
+    """
+
+    _name = "runbot.opencode.bundle"
+    _description = "Runbot OpenCode mounted bundle"
+    _order = "sequence, id"
+    _rec_name = "dir_name"
+
+    bundle_id = fields.Many2one(
+        "runbot.bundle",
+        required=True,
+        index=True,
+        ondelete="cascade",
+    )
+    project_id = fields.Many2one(related="bundle_id.project_id")
+    trigger_id = fields.Many2one(
+        "runbot.trigger",
+        required=True,
+        domain="[('project_id', '=', project_id)]",
+        help="A bundle's build batch has one build per trigger; this picks which "
+        "trigger's build is mounted (e.g. the full OBA build vs the modified-modules one).",
+    )
+    dir_name = fields.Char(
+        required=True,
+        help="Folder the bundle is mounted under in the workspace (e.g. oba-18). "
+        "Must be unique; name it per project when mounting the same version of "
+        "several projects (oba-18, odumbo-18).",
+    )
+    active = fields.Boolean(default=True)
+    sequence = fields.Integer(default=10)
+
+    _sql_constraints = [
+        ("bundle_uniq", "unique(bundle_id)", "This bundle is already exposed."),
+        ("dir_name_uniq", "unique(dir_name)", "The mount folder must be unique."),
+    ]
+
+    def _latest_build(self):
+        """Latest finished build of this bundle for the chosen trigger, or an
+        empty recordset if none. Only builds in 'running' or 'done' count: those
+        are up, with their sources checked out on disk."""
+        self.ensure_one()
+        slots = self.bundle_id.last_done_batch.slot_ids.filtered(lambda s: s.trigger_id == self.trigger_id)
+        builds = slots.build_id.filtered(lambda b: b.params_id and b.global_state in ("running", "done"))
+        return builds[:1]

--- a/runbot_opencode/models/runbot_opencode_workspace.py
+++ b/runbot_opencode/models/runbot_opencode_workspace.py
@@ -1,0 +1,360 @@
+import http.client
+import logging
+import os
+import socket
+import subprocess
+import time
+
+from odoo import _, api, fields, models
+from odoo.addons.runbot.container import sanitize_container_name
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+DOCKER_TIMEOUT = 20
+# Symlink each oba-XX dir carries, pointing at its build's read-only sources.
+OBA_REPOSITORIES_LINK = "repositories"
+# Seconds to wait for OpenCode to answer HTTP after docker run.
+READY_TIMEOUT = 30.0
+# ICP -> environment variable for each AI provider key. Only keys with a
+# non-empty ICP are passed into the container.
+API_KEY_ENV = {
+    "runbot_opencode.anthropic_api_key": "ANTHROPIC_API_KEY",
+    "runbot_opencode.openai_api_key": "OPENAI_API_KEY",
+}
+
+
+class RunbotOpencodeWorkspace(models.Model):
+    """One OpenCode container per user: a personal, always-latest workspace.
+
+    There is a single workspace per user (not tied to any build). It mounts the
+    configured bundles' latest builds read-only so the user can read or ask
+    questions about the code, plus a writable area for their own notes that
+    survives between sessions.
+    """
+
+    _name = "runbot.opencode.workspace"
+    _description = "Runbot OpenCode per-user workspace"
+    _inherit = ["mail.thread"]
+
+    user_id = fields.Many2one(
+        "res.users",
+        required=True,
+        index=True,
+        ondelete="cascade",
+    )
+    user_key = fields.Char(compute="_compute_user_key", store=True)
+    container_name = fields.Char(compute="_compute_container_name", store=True)
+    port = fields.Integer()
+    state = fields.Selection(
+        [
+            ("idle", "Idle"),
+            ("creating", "Creating"),
+            ("running", "Running"),
+            ("error", "Error"),
+        ],
+        default="idle",
+        required=True,
+    )
+    last_activity = fields.Datetime(default=fields.Datetime.now)
+
+    _sql_constraints = [
+        (
+            "user_uniq",
+            "unique(user_id)",
+            "A user can only have one OpenCode workspace.",
+        ),
+    ]
+
+    @api.depends("user_id")
+    def _compute_user_key(self):
+        signer = self.env["runbot.token.signer"]
+        for workspace in self:
+            workspace.user_key = signer._user_key(workspace.user_id) if workspace.user_id else False
+
+    @api.depends("user_key")
+    def _compute_container_name(self):
+        for workspace in self:
+            workspace.container_name = (
+                sanitize_container_name(f"opencode_{workspace.user_key}") if workspace.user_key else False
+            )
+
+    # --- host path helpers -------------------------------------------------
+
+    def _get_host_auth_dir_path(self):
+        """Host folder with this user's state, shared with the VS Code attach
+        (same root, same per-user layout)."""
+        self.ensure_one()
+        root = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(
+                "runbot_attach_vscode.auth_root",
+                default=os.path.expanduser("~/.adhoc-runbot-auth"),
+            )
+        )
+        return os.path.join(root, self.user_key)
+
+    def _get_host_workspace_dir_path(self):
+        """Host folder mounted into the container as /workspace."""
+        self.ensure_one()
+        return os.path.join(self._get_host_auth_dir_path(), "opencode-workspace")
+
+    # --- port pool ---------------------------------------------------------
+
+    @api.model
+    def _find_free_port(self):
+        """Return a free host port on loopback, picked by the OS (bind to 0)."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            return sock.getsockname()[1]
+
+    # --- latest build sources ---------------------------------------------
+
+    def _get_host_builds_root_path(self):
+        """Host folder with every build's data (runbot's static). Mounted
+        read-only as .odoodata so the oba-XX `repositories` symlinks resolve to
+        a build's sources inside the container, and the code stays read-only."""
+        return self.env["runbot.runbot"]._path()
+
+    def _get_host_oba_project_path(self):
+        """Host path of the oba-project checkout."""
+        return (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("runbot_opencode.oba_project_path", default="/home/runbot/sync-repos/oba-project")
+        )
+
+    def _get_oba_project_memory_path(self):
+        """Host path of the oba-project memory dir."""
+        return (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("runbot_opencode.oba_project_memory_path", default="/home/runbot/sync-repos/oba-project-memory")
+        )
+
+    def _get_bundles_env(self):
+        """Build the OPENCODE_BUNDLES value: "dir_name:build_id,..." for each
+        configured bundle, skipping those without a latest build."""
+        entries = []
+        for bundle in self.env["runbot.opencode.bundle"].search([]):
+            build = bundle._latest_build()
+            if build:
+                entries.append(f"{bundle.dir_name}:{build.id}")
+        return ",".join(entries)
+
+    def _get_public_url(self):
+        """Public address nginx serves this workspace at; matches the redirect
+        target the controller sends the browser to (opencode-<user_key>.<host>)."""
+        self.ensure_one()
+        scheme = self.env["ir.config_parameter"].sudo().get_param("runbot_opencode.scheme", default="https")
+        host = self.env["runbot.host"]._get_current_name()
+        return f"{scheme}://opencode-{self.user_key}.{host}"
+
+    # --- workspace files ---------------------------------------------------
+
+    def _ensure_files(self):
+        """Create the host folders the container mounts."""
+        self.ensure_one()
+        # Writable area for the user's own files.
+        os.makedirs(os.path.join(self._get_host_workspace_dir_path(), "personal"), exist_ok=True)
+        # Create the mounted subdirs as the runbot user, so they aren't created
+        # as root by Docker on mount.
+        auth_dir = self._get_host_auth_dir_path()
+        for sub in (".cache", ".config", ".local", ".adhoc"):
+            os.makedirs(os.path.join(auth_dir, sub), exist_ok=True)
+
+    # --- container lifecycle ----------------------------------------------
+
+    def _docker_container_running(self):
+        self.ensure_one()
+        try:
+            result = subprocess.run(
+                ["docker", "inspect", "-f", "{{.State.Running}}", self.container_name],
+                capture_output=True,
+                timeout=DOCKER_TIMEOUT,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False
+        return result.returncode == 0 and result.stdout.strip() == b"true"
+
+    @api.model
+    def _ensure_workspace(self, user):
+        """Find or create the user's workspace and make sure it is running.
+        Returns the workspace record."""
+        workspace = self.search([("user_id", "=", user.id)], limit=1)
+        if not workspace:
+            workspace = self.create({"user_id": user.id})
+        workspace._ensure_container()
+        return workspace
+
+    def _ensure_container(self):
+        """Start the user's container if it isn't already running, refreshing
+        the sources first. Calling it again while it is up only refreshes the
+        sources and the last-activity stamp."""
+        self.ensure_one()
+        self._ensure_files()
+        if self._docker_container_running():
+            self.write({"state": "running", "last_activity": fields.Datetime.now()})
+            return
+
+        self.state = "creating"
+        image = self.env["ir.config_parameter"].sudo().get_param("runbot_opencode.image")
+        if not image:
+            self.state = "error"
+            raise UserError(_("Set the OpenCode image in runbot_opencode.image first."))
+        if not self.port:
+            self.port = self._find_free_port()
+
+        host_workspace_dir_path = self._get_host_workspace_dir_path()
+        host_builds_root_path = self._get_host_builds_root_path()
+        host_oba_project_path = self._get_host_oba_project_path()
+        host_oba_project_memory_path = self._get_oba_project_memory_path()
+        host_auth_dir_path = self._get_host_auth_dir_path()
+        cmd = [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            self.container_name,
+            "-p",
+            f"127.0.0.1:{self.port}:4096",
+            # Mount the per-user home subdirs OpenCode and adhoc-way write to
+            # (.cache, .config, .local, .adhoc) so the user's identity, config
+            # and logins persist between sessions, without exposing the rest of
+            # the image's HOME.
+            "-v",
+            f"{host_auth_dir_path}/.cache:/home/odoo/.cache:rw",
+            "-v",
+            f"{host_auth_dir_path}/.config:/home/odoo/.config:rw",
+            "-v",
+            f"{host_auth_dir_path}/.local:/home/odoo/.local:rw",
+            "-v",
+            f"{host_auth_dir_path}/.adhoc:/home/odoo/.adhoc:rw",
+            # Mount the user's workspace folder as /workspace so they can read and write their own files, and so OpenCode can store its own state there.
+            "-v",
+            f"{host_workspace_dir_path}:/home/odoo/workspace:rw",
+            # Mount the whole builds root as .odoodata so the oba-XX symlinks resolve
+            "-v",
+            f"{host_builds_root_path}:/home/odoo/ctx/.odoodata:ro",
+            # Shared, read-only oba-project (AGENTS.md, memory, conventions);
+            # each bundle dir symlinks its entries in (see _ensure_oba_sources).
+            "-v",
+            f"{host_oba_project_path}:/home/odoo/ctx/.oba-project:ro",
+            # Mount the oba-project memory dir read-only.
+            "-v",
+            f"{host_oba_project_memory_path}:/home/odoo/ctx/.oba-project-memory:ro",
+        ]
+        # Pass each configured AI key as an environment variable; skip the ones
+        # left empty so we never inject a blank key.
+        get_param = self.env["ir.config_parameter"].sudo().get_param
+        for icp, env_var in API_KEY_ENV.items():
+            value = get_param(icp)
+            if value:
+                cmd += ["-e", f"{env_var}={value}"]
+
+        # Tell the container which build's sources sit under each bundle dir.
+        bundles_env = self._get_bundles_env()
+        if bundles_env:
+            cmd += ["-e", f"OPENCODE_BUNDLES={bundles_env}"]
+
+        # Let the container know its own public address.
+        cmd += ["-e", f"OPENCODE_PUBLIC_URL={self._get_public_url()}"]
+
+        # The image's ENTRYPOINT runs adhoc-way init and boots `opencode serve`,
+        # so we run it with no command.
+        cmd += [image]
+        try:
+            result = subprocess.run(cmd, capture_output=True, timeout=DOCKER_TIMEOUT, check=False)
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            self.state = "error"
+            _logger.exception("docker run failed for workspace %s", self.id)
+            raise UserError(_("Could not start the OpenCode container."))
+        if result.returncode != 0:
+            self.state = "error"
+            _logger.error(
+                "docker run for opencode workspace %s failed (rc=%s): %s",
+                self.id,
+                result.returncode,
+                result.stderr.decode("utf-8", errors="replace"),
+            )
+            raise UserError(_("Could not start the OpenCode container."))
+        self._wait_until_ready()
+        self.write({"state": "running", "last_activity": fields.Datetime.now()})
+        self._log_audit("opened")
+
+    def _wait_until_ready(self):
+        """Wait until OpenCode answers HTTP. docker opens the port as soon as
+        the container starts, but OpenCode needs a moment more to serve; without
+        this wait the user's first request would hit an error page."""
+        self.ensure_one()
+        deadline = time.monotonic() + READY_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", self.port, timeout=0.5)
+                try:
+                    conn.request("GET", "/")
+                    resp = conn.getresponse()
+                    resp.read()
+                finally:
+                    conn.close()
+                if resp.status < 500:
+                    return
+            except (OSError, http.client.HTTPException):
+                pass
+            time.sleep(0.3)
+        self.state = "error"
+        _logger.error("OpenCode on port %s not ready in %ss", self.port, READY_TIMEOUT)
+        raise UserError(_("OpenCode did not start in time; try again."))
+
+    def _stop_container(self):
+        for workspace in self:
+            if workspace.container_name:
+                try:
+                    subprocess.run(
+                        ["docker", "rm", "-f", workspace.container_name],
+                        capture_output=True,
+                        timeout=DOCKER_TIMEOUT,
+                        check=False,
+                    )
+                except (subprocess.TimeoutExpired, FileNotFoundError):
+                    _logger.warning("docker rm failed for %s", workspace.container_name)
+            # The workspace folder is left on the host, so the user keeps their
+            # files between sessions.
+            if workspace.state == "running":
+                workspace._log_audit("closed")
+            workspace.write({"state": "idle", "port": False})
+
+    def action_stop_container(self):
+        """Stop button on the admin form (buttons can't call private methods)."""
+        self._stop_container()
+
+    def touch(self):
+        """Mark the workspace as recently used (called by the auth check).
+
+        Write at most once a minute: OpenCode makes many requests and the
+        cleanup job only looks every few hours, so writing on each one is wasted."""
+        threshold = fields.Datetime.subtract(fields.Datetime.now(), seconds=60)
+        to_refresh = self.filtered(lambda w: not w.last_activity or w.last_activity < threshold)
+        if to_refresh:
+            to_refresh.sudo().write({"last_activity": fields.Datetime.now()})
+
+    def _log_audit(self, event):
+        """Post an internal note recording who opened/closed the workspace."""
+        self.ensure_one()
+        self.message_post(
+            body=_("OpenCode workspace %s by %s", event, self.user_id.name),
+            subtype_xmlid="mail.mt_note",
+        )
+
+    @api.model
+    def _cron_close_unused_workspaces(self):
+        """Stop workspaces nobody has used for a while (ICP idle_timeout_hours,
+        default 8h). The container is removed; the workspace record and the
+        user's files stay."""
+        hours = int(self.env["ir.config_parameter"].sudo().get_param("runbot_opencode.idle_timeout_hours", default="8"))
+        deadline = fields.Datetime.subtract(fields.Datetime.now(), hours=hours)
+        unused = self.search([("state", "=", "running"), ("last_activity", "<", deadline)])
+        unused._stop_container()

--- a/runbot_opencode/models/runbot_opencode_workspace.py
+++ b/runbot_opencode/models/runbot_opencode_workspace.py
@@ -21,6 +21,7 @@ READY_TIMEOUT = 30.0
 API_KEY_ENV = {
     "runbot_opencode.anthropic_api_key": "ANTHROPIC_API_KEY",
     "runbot_opencode.openai_api_key": "OPENAI_API_KEY",
+    "runbot_opencode.moonshotai_api_key": "MOONSHOTAI_API_KEY",
 }
 
 

--- a/runbot_opencode/security/ir.model.access.csv
+++ b/runbot_opencode/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_runbot_opencode_workspace_user,runbot.opencode.workspace.user,model_runbot_opencode_workspace,runbot.group_user,1,0,0,0
+access_runbot_opencode_workspace_admin,runbot.opencode.workspace.admin,model_runbot_opencode_workspace,runbot.group_runbot_admin,1,1,1,1
+access_runbot_opencode_bundle_user,runbot.opencode.bundle.user,model_runbot_opencode_bundle,runbot.group_user,1,0,0,0
+access_runbot_opencode_bundle_admin,runbot.opencode.bundle.admin,model_runbot_opencode_bundle,runbot.group_runbot_admin,1,1,1,1

--- a/runbot_opencode/views/runbot_frontend_templates.xml
+++ b/runbot_opencode/views/runbot_frontend_templates.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Add "OpenCode" to the user menu, next to "Logout" and "Web". Clicking
+         it opens (creating if needed) the user's personal workspace. -->
+    <template id="runbot_layout_opencode_menu" inherit_id="runbot.layout">
+        <xpath expr="//div[hasclass('js_usermenu')]/a[@t-attf-href='/web']" position="after">
+            <a class="dropdown-item"
+               groups="base.group_user"
+               role="menuitem"
+               href="/runbot/opencode"
+               target="_blank">OpenCode</a>
+        </xpath>
+    </template>
+
+</odoo>

--- a/runbot_opencode/views/runbot_nginx.xml
+++ b/runbot_opencode/views/runbot_nginx.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- One server block per running workspace, reached at
+         <suffix>-<user_key>.<host>. Workspaces are per-user (not per-build),
+         so this goes in root_anchor, outside runbot's loop over builds.
+
+         ACCESS CHECK: before every request, nginx asks
+         /runbot/opencode/auth_check?user=<user_key>. The controller checks the
+         token is valid, not expired, and owned by this user — so user A's token
+         cannot open user B's workspace. No valid token sends the user to
+         /runbot/opencode, which gives them a fresh one (or the login page).
+
+         The Connection header switches between "upgrade" and "close" so the
+         same block serves both OpenCode's web pages and its live connection.
+         The 7-day timeouts keep long sessions open. -->
+    <record id="runbot_nginx_config_opencode" model="ir.ui.view">
+        <field name="name">runbot.nginx_config.opencode</field>
+        <field name="type">qweb</field>
+        <field name="inherit_id" ref="runbot.nginx_config"/>
+        <field name="arch" type="xml">
+            <xpath expr="//t[@id='root_anchor']" position="after">
+                <t t-foreach="env['runbot.opencode.workspace'].search([('state', '=', 'running'), ('port', '!=', False)])" t-as="workspace">
+server {
+    listen 8080;
+    server_name ~^opencode-<t t-out="re_escape(workspace.user_key)"/>\.<t t-out="re_escape(host_name)"/>$;
+
+    location = /__opencode_auth_check {
+        internal;
+        proxy_pass http://127.0.0.1:8069/runbot/opencode/auth_check?user=<t t-out="workspace.user_key"/>;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header Host <t t-out="host_name"/>;
+        proxy_set_header X-Forwarded-Proto $real_scheme;
+    }
+
+    location @opencode_login_redirect {
+        return 302 $real_scheme://<t t-out="host_name"/>/runbot/opencode;
+    }
+
+    # Public OAuth callback (state+PKCE-secured); bypass auth_request so the cross-site redirect from the provider isn't 302'd to login.
+    location = /mcp/oauth/callback {
+        proxy_pass http://127.0.0.1:<t t-out="workspace.port"/>;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $real_scheme;
+    }
+
+    location / {
+        auth_request /__opencode_auth_check;
+        error_page 401 403 = @opencode_login_redirect;
+
+        proxy_pass http://127.0.0.1:<t t-out="workspace.port"/>;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $real_scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        set $opencode_conn_upgrade upgrade;
+        if ($http_upgrade = "") { set $opencode_conn_upgrade close; }
+        proxy_set_header Connection $opencode_conn_upgrade;
+        proxy_read_timeout 7d;
+        proxy_send_timeout 7d;
+    }
+}
+                </t>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/runbot_opencode/views/runbot_opencode_bundle_views.xml
+++ b/runbot_opencode/views/runbot_opencode_bundle_views.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="runbot_opencode_bundle_view_list" model="ir.ui.view">
+        <field name="name">runbot.opencode.bundle.list</field>
+        <field name="model">runbot.opencode.bundle</field>
+        <field name="arch" type="xml">
+            <list editable="bottom">
+                <field name="sequence" widget="handle"/>
+                <field name="bundle_id"/>
+                <field name="project_id"/>
+                <field name="trigger_id"/>
+                <field name="dir_name"/>
+                <field name="active" widget="boolean_toggle"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="runbot_opencode_bundle_view_form" model="ir.ui.view">
+        <field name="name">runbot.opencode.bundle.form</field>
+        <field name="model">runbot.opencode.bundle</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="bundle_id"/>
+                        <field name="project_id"/>
+                        <field name="trigger_id"/>
+                        <field name="dir_name"/>
+                        <field name="active"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="runbot_opencode_bundle_action" model="ir.actions.act_window">
+        <field name="name">OpenCode Bundles</field>
+        <field name="res_model">runbot.opencode.bundle</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="runbot_menu_opencode_bundle"
+              parent="runbot_menu_opencode"
+              sequence="20"
+              action="runbot_opencode_bundle_action"
+              groups="runbot.group_runbot_admin"/>
+
+</odoo>

--- a/runbot_opencode/views/runbot_opencode_workspace_views.xml
+++ b/runbot_opencode/views/runbot_opencode_workspace_views.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="runbot_opencode_workspace_view_list" model="ir.ui.view">
+        <field name="name">runbot.opencode.workspace.list</field>
+        <field name="model">runbot.opencode.workspace</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="user_id"/>
+                <field name="state"/>
+                <field name="port"/>
+                <field name="container_name"/>
+                <field name="last_activity"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="runbot_opencode_workspace_view_form" model="ir.ui.view">
+        <field name="name">runbot.opencode.workspace.form</field>
+        <field name="model">runbot.opencode.workspace</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="action_stop_container" type="object" string="Stop container"
+                            confirm="Stop this workspace's container? The user's files are kept."/>
+                    <field name="state" widget="statusbar"/>
+                </header>
+                <sheet>
+                    <group>
+                        <field name="user_id"/>
+                        <field name="user_key"/>
+                        <field name="container_name"/>
+                        <field name="port"/>
+                        <field name="last_activity"/>
+                    </group>
+                </sheet>
+                <chatter/>
+            </form>
+        </field>
+    </record>
+
+    <record id="runbot_opencode_workspace_action" model="ir.actions.act_window">
+        <field name="name">OpenCode Workspaces</field>
+        <field name="res_model">runbot.opencode.workspace</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="runbot_menu_opencode"
+              name="OpenCode"
+              parent="runbot.menu_runbot_settings"
+              sequence="90"
+              groups="runbot.group_runbot_admin"/>
+
+    <menuitem id="runbot_menu_opencode_workspace"
+              parent="runbot_menu_opencode"
+              sequence="10"
+              action="runbot_opencode_workspace_action"
+              groups="runbot.group_runbot_admin"/>
+
+</odoo>

--- a/runbot_token_auth/models/runbot_token_signer.py
+++ b/runbot_token_auth/models/runbot_token_signer.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import hmac
+import re
 import time
 
 from odoo import models
@@ -18,6 +19,15 @@ class RunbotTokenSigner(models.AbstractModel):
 
     _name = "runbot.token.signer"
     _description = "Runbot signed access token"
+
+    def _user_key(self, user):
+        """Public per-user handle `<id>-<login-slug>` used in the workspace
+        subdomain and the shared host folder. Both per-user container modules
+        derive it the same way so they land on the same folder; auth_check only
+        relies on the leading `<id>-`, the slug is just there to keep it readable."""
+        local_part = (user.login or "").split("@")[0]
+        slug = re.sub(r"[^a-z0-9]+", "-", local_part.lower()).strip("-")
+        return f"{user.id}-{slug}" if slug else str(user.id)
 
     def _secret(self):
         """Key used to sign tokens: the database secret, or the database uuid as

--- a/runbot_token_auth/tests/test_runbot_token_auth.py
+++ b/runbot_token_auth/tests/test_runbot_token_auth.py
@@ -31,3 +31,14 @@ class TestRunbotTokenAuth(TransactionCase):
                     [str(build_id), str(user_id), str(2**31)],
                     f"token for build={build_id} user={user_id} failed to verify",
                 )
+
+    def test_user_key(self):
+        """The shared per-user key is `<id>-<login-slug>`: the slug keeps only
+        the part before the `@` and slugifies it, so the per-user container
+        modules all land on the same handle. auth_check parses the leading id."""
+        signer = self.env["runbot.token.signer"]
+        user = self.env["res.users"].create({"name": "Key User", "login": "key.user@example.com"})
+        self.assertEqual(signer._user_key(user), f"{user.id}-key-user")
+        # a login with nothing slug-worthy falls back to the bare id.
+        odd = self.env["res.users"].create({"name": "Odd", "login": "@@@"})
+        self.assertEqual(signer._user_key(odd), str(odd.id))


### PR DESCRIPTION
## Qué hace

Nuevo módulo `runbot_opencode`: cada usuario interno puede abrir desde Runbot un workspace personal de OpenCode, siempre sobre las últimas builds terminadas de OBA, sin setup local. Pensado tanto para devs como para funcionales/POs que quieren explorar el código de OBA.

## Cambios

**`[IMP] runbot_token_auth`** — helper compartido `_user_key(user)` en el `runbot.token.signer`. Los módulos de container per-usuario derivan el handle público `<id>-<login-slug>` de la misma forma (mismo dir compartido en el host) y el contrato del prefijo `<id>-` que parsea `auth_check` queda junto a la verificación del token. `runbot_attach_vscode` pasa a delegar en él (saca la lógica duplicada). Sin cambio de comportamiento: el slug es cosmético, el token sigue ligado a `user_id`.

**`[ADD] runbot_opencode`**:
- `runbot.opencode.workspace`: un container por usuario (único por `user_id`), con estado/puerto/last_activity. `_ensure_workspace` hace find-or-create y arranca; un `ir.cron` mata los idle (remueve el container, conserva los archivos del usuario).
- `runbot.opencode.bundle`: los bundles a montar, configurables desde la UI. Cada registro fija un `runbot.bundle` + `trigger` (el nombre de bundle se repite entre proyectos, así que elegir el registro saca la ambigüedad) y el folder de montaje `dir_name`.
- Fuentes: `static/build` montado read-only como `.odoodata`; el container clona (o `pull`) `ingadhoc/oba-project` bajo cada `dir_name` y corre `update-build` para repuntar el symlink `repositories` a la última build. Read-only porque `.odoodata` es `:ro`.
- Auth: token firmado vía `runbot.token.signer` + un bloque nginx por workspace corriendo; el controller valida que el token sea dueño de la dirección.
- Imagen y API keys de IA salen de ICPs; el MCP/skills/conventions los deja adhoc-way horneado en la imagen.

## Test plan

- `runbot_token_auth`: `test_user_key` (formato `<id>-<slug>` + fallback) y los de token siguen verdes.
- Verificar en runbot: opción "OpenCode" en el dropdown de usuario → crea/arranca el container y redirige al subdominio; sin cookie válida redirige a login.
- Cargar un `runbot.opencode.bundle` (bundle + trigger + dir) y confirmar que dentro del container `<dir>/repositories` resuelve a la build y es read-only, mientras `personal/` es escribible.

Tarea: https://odoo.adhoc.com.ar/odoo/project/902/tasks/68967