### PR TITLE
[ADD] runbot_ux: mirror provider auto-install policy in builds

### DIFF
--- a/runbot_ux/README.rst
+++ b/runbot_ux/README.rst
@@ -1,0 +1,69 @@
+=========
+Runbot UX
+=========
+
+Personalizaciones de Adhoc sobre Runbot: selección dinámica de módulos a
+testear, manejo seguro del addons path y réplica en los builds de la política de
+auto-instalación de las bases cliente.
+
+Características
+===============
+
+- **Selección dinámica de** ``--test-tags``: al correr tests, deriva los tags a
+  partir de patrones definidos por repo (campo *Modules to test*). Soporta
+  comodines ``fnmatch`` (``sale,account_*``) y exclusiones con ``-``
+  (``-*,sale``).
+- **Addons path seguro**: omite paths inexistentes o no válidos (repos vacíos de
+  versiones nuevas / OCA) para que Odoo levante igual.
+- **Política de auto-instalación por versión**: los builds auto-instalan los
+  mismos módulos que las bases cliente, según ``force_auto_install`` de
+  ``adhoc.module.module`` en el provider. Un cron diario sincroniza las listas
+  por versión y se inyectan en el ``.odoorc`` de cada build.
+
+Configuración
+=============
+
+La feature de auto-instalación requiere:
+
+- **Endpoint del provider**: ``/saas_provider/get_runbot_auto_install_data`` en
+  ``saas_provider_adhoc`` (devuelve, por versión, las listas derivadas de
+  ``force_auto_install``).
+- **System parameters** en el runbot:
+
+  - ``runbot_ux.provider_url``: URL base del provider.
+  - ``runbot_ux.provider_token``: mismo valor que
+    ``saas_provider.odoo_project_token`` del provider.
+
+- **server_wide_modules**: el *default odoorc* de los builds debe incluir
+  ``saas_client`` (ej. ``server_wide_modules = base,web,saas_client``), para que
+  su patch de ``load_manifest`` esté activo al arrancar y aplique las claves
+  inyectadas.
+
+Sin los system parameters el cron loguea una advertencia y no sincroniza; sin
+``saas_client`` cargado server-wide las claves inyectadas no tienen efecto.
+
+Uso
+===
+
+- **Tests por módulo**: setear *Modules to test* en el repo (patrones). Vacío =
+  todos los módulos; para desactivar la inyección, desmarcar *Test Enable* en el
+  config step.
+- **Auto-instalación**: se marca ``force_auto_install`` en
+  ``adhoc.module.module`` (provider); el cron diario trae las listas y cada build
+  las aplica automáticamente. Las listas sincronizadas se ven en la lista de
+  *Versions* (columnas opcionales).
+
+Dependencias
+============
+
+- ``runbot``
+
+Autor
+=====
+
+ADHOC SA
+
+Licencia
+========
+
+AGPL-3

--- a/runbot_ux/__manifest__.py
+++ b/runbot_ux/__manifest__.py
@@ -7,8 +7,10 @@
     "version": "18.0.1.1.0",
     "depends": ["runbot"],
     "data": [
+        "data/runbot_ux_data.xml",
         "views/config_step_views.xml",
         "views/repo_views.xml",
+        "views/runbot_version_views.xml",
     ],
     "demo": [
         "demo/runbot_ux_demo.xml",

--- a/runbot_ux/data/runbot_ux_data.xml
+++ b/runbot_ux/data/runbot_ux_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="ir_cron_fetch_auto_install_data" model="ir.cron">
+        <field name="name">Runbot: sync auto-install policy from provider</field>
+        <field name="model_id" ref="runbot.model_runbot_version"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_fetch_auto_install_data()</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="active" eval="True"/>
+    </record>
+</odoo>

--- a/runbot_ux/models/__init__.py
+++ b/runbot_ux/models/__init__.py
@@ -2,3 +2,4 @@ from . import runbot_build
 from . import runbot_build_config
 from . import runbot_repo
 from . import runbot_trigger
+from . import runbot_version

--- a/runbot_ux/models/runbot_build.py
+++ b/runbot_ux/models/runbot_build.py
@@ -1,3 +1,4 @@
+import configparser
 import fnmatch
 import os
 
@@ -66,3 +67,47 @@ class RunbotBuild(models.Model):
             modules_to_test |= repo_modules
 
         return ["/" + module for module in sorted(modules_to_test)]
+
+    def _docker_run(self, *args, **kwargs):
+        res = super()._docker_run(*args, **kwargs)
+        # The base method has just written .odoorc; inject the auto-install
+        # policy so the build honors the same modules as client bases.
+        self._inject_auto_install_config()
+        return res
+
+    def _inject_auto_install_config(self):
+        """Write the version's auto-install lists into the build's .odoorc.
+
+        Key names differ by version: 19.0+ uses the [module_change_auto_install]
+        section, 18.0 and older use the flat [options] keys. Both are read by the
+        saas_client patch.
+        """
+        self.ensure_one()
+        version = self.params_id.version_id
+        enabled = version.modules_auto_install_enabled or ""
+        disabled = version.modules_auto_install_disabled or ""
+        if not enabled and not disabled:
+            return  # nothing to inject (e.g. master, which has no policy)
+
+        if version.name >= "19.0":
+            section, key_enabled, key_disabled = "module_change_auto_install", "modules_enabled", "modules_disabled"
+        else:
+            section, key_enabled, key_disabled = (
+                "options",
+                "modules_auto_install_enabled",
+                "modules_auto_install_disabled",
+            )
+
+        rc_path = self._path(".odoorc")
+        if not os.path.exists(rc_path):
+            return
+        # RawConfigParser: no %-interpolation, so existing values (e.g. log
+        # formats) with '%' don't blow up on read.
+        parser = configparser.RawConfigParser()
+        parser.read(rc_path)
+        if not parser.has_section(section):
+            parser.add_section(section)
+        parser.set(section, key_enabled, enabled)
+        parser.set(section, key_disabled, disabled)
+        with open(rc_path, "w") as rc_file:
+            parser.write(rc_file)

--- a/runbot_ux/models/runbot_version.py
+++ b/runbot_ux/models/runbot_version.py
@@ -1,0 +1,56 @@
+import logging
+
+import requests
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class RunbotVersion(models.Model):
+    _inherit = "runbot.version"
+
+    modules_auto_install_enabled = fields.Text(
+        readonly=True,
+        help="Comma-separated modules forced to auto-install for this version. "
+        "Synced daily from the provider (adhoc.module.module) and injected into "
+        "each build's odoorc so builds match client bases.",
+    )
+    modules_auto_install_disabled = fields.Text(
+        readonly=True,
+        help="Comma-separated modules whose auto-install is disabled for this version. "
+        "Synced daily from the provider (adhoc.module.module) and injected into "
+        "each build's odoorc so builds match client bases.",
+    )
+
+    def _cron_fetch_auto_install_data(self):
+        """Sync each version's auto-install policy from the provider. On error the
+        previous value is kept."""
+        provider_url = self.env["ir.config_parameter"].get_param("runbot_ux.provider_url")
+        token = self.env["ir.config_parameter"].get_param("runbot_ux.provider_token")
+        if not provider_url or not token:
+            _logger.warning("runbot_ux: provider_url/token not configured; skipping auto-install sync")
+            return
+
+        endpoint = provider_url.rstrip("/") + "/saas_provider/get_runbot_auto_install_data"
+        for version in self.search([("name", "!=", "master")]):
+            try:
+                response = requests.post(
+                    endpoint,
+                    json={"jsonrpc": "2.0", "method": "call", "params": {"major_version": version.name}},
+                    headers={"token": token},
+                    timeout=30,
+                )
+                response.raise_for_status()
+                result = response.json().get("result") or {}
+                if result.get("error"):
+                    raise ValueError(result["error"])
+            except Exception as e:
+                _logger.warning("runbot_ux: could not sync auto-install data for %s: %s", version.name, e)
+                continue  # keep last known good value
+
+            version.write(
+                {
+                    "modules_auto_install_enabled": ",".join(result.get("enabled", [])),
+                    "modules_auto_install_disabled": ",".join(result.get("disabled", [])),
+                }
+            )

--- a/runbot_ux/views/runbot_version_views.xml
+++ b/runbot_ux/views/runbot_version_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_runbot_version_tree_ux" model="ir.ui.view">
+        <field name="model">runbot.version</field>
+        <field name="inherit_id" ref="runbot.view_runbot_version_tree"/>
+        <field name="arch" type="xml">
+            <field name="dockerfile_id" position="after">
+                <field name="modules_auto_install_enabled" optional="hide"/>
+                <field name="modules_auto_install_disabled" optional="hide"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Runbot builds installed everything `auto_install` per manifest, ignoring the curated `force_auto_install` policy, so builds diverged from client bases.

This adds:
- `modules_auto_install_enabled`/`modules_auto_install_disabled` on `runbot.version` (readonly, shown in the Versions list).
- A daily cron that syncs those lists from the provider endpoint, keeping the last value on error.
- Version-aware injection of the lists into each build's `.odoorc` (`[module_change_auto_install]` for 19.0+, `[options]` for <19), so the `saas_client` patch honors them at install time.

Requires the companion endpoint in `saas_provider_adhoc` and, on the runbot side, the system params `runbot_ux.provider_url` / `runbot_ux.provider_token` plus `saas_client` in `server_wide_modules` of the build default odoorc (see README).

Task #69086
